### PR TITLE
Feature/add mocha report parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # test-results-parser
 
-Parse test results from JUnit, TestNG, xUnit and many more
+Parse test results from JUnit, TestNG, xUnit, Mocha and many more
 
 ## Support
 
-| Result Type | Support |
-|-------------|---------|
-| TestNG      | ✅       |
-| JUnit       | ✅       |
-| xUnit       | ✅       |
+| Result Type                   | Support |
+|-------------------------------|---------|
+| TestNG                        | ✅      |
+| JUnit                         | ✅      |
+| xUnit                         | ✅      |
+| Mocha (json & mochawesome)    | ✅      |

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -8,13 +8,6 @@ function getJsonFromXMLFile(filePath) {
   return parser.parse(xml, { arrayMode: true, ignoreAttributes: false, parseAttributeValue: true });
 }
 
-function getJsonFromFile(filePath) {
-  const cwd = process.cwd();
-  const jsonFile = fs.readFileSync(path.join(cwd, filePath));
-  return JSON.parse(jsonFile);
-}
-
 module.exports = {
-  getJsonFromXMLFile,
-  getJsonFromFile
+  getJsonFromXMLFile
 }

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -8,6 +8,13 @@ function getJsonFromXMLFile(filePath) {
   return parser.parse(xml, { arrayMode: true, ignoreAttributes: false, parseAttributeValue: true });
 }
 
+function getJsonFromFile(filePath) {
+  const cwd = process.cwd();
+  const jsonFile = fs.readFileSync(path.join(cwd, filePath));
+  return JSON.parse(jsonFile);
+}
+
 module.exports = {
-  getJsonFromXMLFile
+  getJsonFromXMLFile,
+  getJsonFromFile
 }

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,6 +1,7 @@
 const testng = require('./testng');
 const junit = require('./junit');
 const xunit = require('./xunit');
+const mocha = require('./mocha');
 
 function parse(options) {
   switch (options.type) {
@@ -10,6 +11,8 @@ function parse(options) {
       return junit.parse(options);
     case 'xunit':
       return xunit.parse(options);
+    case 'mocha':
+        return mocha.parse(options);
     default:
       throw `UnSupported Result Type - ${options.type}`;
   }

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -1,0 +1,115 @@
+/*
+*  Parser for both Mocha Json report and Mochawesome json
+*/
+const { getJsonFromFile } = require('../helpers/helper');
+
+const TestResult = require('../models/TestResult');
+const TestSuite = require('../models/TestSuite');
+const TestCase = require('../models/TestCase');
+
+function getTestCase(rawCase) {
+  const test_case = new TestCase();
+  test_case.name = rawCase["title"];
+  test_case.duration = rawCase["duration"] * 1000;
+  if (rawCase["state"] == "pending") {
+    test_case.status = 'SKIP';
+  }
+  else if (rawCase.state && rawCase.state === "failed") {
+    test_case.status = 'FAIL';
+    test_case.failure = rawCase.err["message"];
+  }
+  else {
+    test_case.status = 'PASS';
+  }
+  return test_case;
+}
+
+function getTestSuite(rawSuite) {
+  const suite = new TestSuite();
+  suite.name = rawSuite["title"];
+  suite.total = rawSuite["tests"].length;
+  suite.passed = rawSuite["passes"].length;
+  suite.failed = rawSuite["failures"].length;
+  suite.duration = rawSuite["duration"] * 1000;
+  suite.skipped = rawSuite["pending"].length;
+  suite.status = suite.total === suite.passed ? 'PASS' : 'FAIL';
+  suite.status = suite.skipped == suite.total ? 'PASS' : suite.status;
+  const raw_test_cases = rawSuite.tests;
+  if (raw_test_cases) {
+    for (let i = 0; i < raw_test_cases.length; i++) {
+      suite.cases.push(getTestCase(raw_test_cases[i]));
+    }
+  }
+  return suite;
+}
+
+function getTestResult(json) {
+  const result = new TestResult();
+  const { stats, results } = formatMochaJsonReport(json);
+  const formattedResult = results[0] || {};
+  const suites = formattedResult["suites"] || [];
+
+  result.name = formattedResult["title"] || "";
+  result.total = stats["tests"];
+  result.passed = stats["passes"];
+  result.failed = stats["failures"];
+  const errors = formattedResult["errors"];
+  if (errors) {
+    result.errors = errors;
+  }
+  const skipped = stats["pending"];
+  if (skipped) {
+    result.skipped = skipped;
+  }
+  result.duration = stats["duration"] * 1000;
+  
+  for (let i = 0; i < suites.length; i++) {
+    result.suites.push(getTestSuite(suites[i]));
+  }
+  result.status = (result.total - result.skipped) === result.passed ? 'PASS' : 'FAIL';
+  return result;
+}
+
+/**
+ * Function to format the mocha raw json report
+ * @param {*} rawjson 
+ * @returns formatted json object
+ */
+function formatMochaJsonReport(rawjson) {
+  if (rawjson.hasOwnProperty('meta')) {
+    return rawjson
+  }
+  const formattedJson = { stats: rawjson.stats, results: [] };
+  const suites = [];
+  rawjson.failures.forEach(test => test.state = "failed");
+  rawjson.passes.forEach(test => test.state = "passed");
+
+  rawjson.pending.forEach(test => test.state = "pending");
+
+  const rawTests = [...rawjson.pending, ...rawjson.passes, ...rawjson.failures];
+  const testSuites = [...new Set(rawTests.map(test => test.fullTitle.split(' ' + test.title)[0]))];
+
+  for (const testSuite of testSuites) {
+    const suite = {
+      title: testSuite,
+      tests: rawTests.filter(test => test.fullTitle.startsWith(testSuite))
+    }
+    suite.passes = suite.tests.filter(test => test.state === "passed");
+    suite.failures = suite.tests.filter(test => test.state === "failed");
+    suite.pending = suite.tests.filter(test => test.state === "pending");
+    suite.duration = suite.tests.map(test => test.duration).reduce((total, currVal) => total + currVal, 0);
+    suite.fullFile = suite.tests[0].file || "";
+    suites.push(suite);
+  }
+  formattedJson.results.push({ suites: suites });
+  return formattedJson;
+}
+
+function parse(options) {
+  const json = getJsonFromFile(options.files[0]);
+  return getTestResult(json);
+}
+
+module.exports = {
+  parse
+}

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -66,8 +66,6 @@ function getTestResult(json) {
     for (let i = 0; i < suites.length; i++) {
       result.suites.push(getTestSuite(suites[i]));
     }
-  } else {
-    console.log("No suites with tests found");
   }
   result.status = (result.total - result.skipped) === result.passed ? 'PASS' : 'FAIL';
   return result;

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -1,7 +1,7 @@
 /*
 *  Parser for both Mocha Json report and Mochawesome json
 */
-const { getJsonFromFile } = require('../helpers/helper');
+const path = require('path');
 
 const TestResult = require('../models/TestResult');
 const TestSuite = require('../models/TestSuite');
@@ -109,9 +109,10 @@ function formatMochaJsonReport(rawjson) {
 }
 
 function parse(options) {
-  const json = getJsonFromFile(options.files[0]);
+  const cwd = process.cwd();
+  const json = require(path.join(cwd, options.files[0]));
   return getTestResult(json);
-}
+} 
 
 module.exports = {
   parse

--- a/tests/data/mocha/awesome/empty-suite.json
+++ b/tests/data/mocha/awesome/empty-suite.json
@@ -1,0 +1,43 @@
+{
+  "stats": {
+    "suites": 0,
+    "tests": 0,
+    "passes": 0,
+    "pending": 0,
+    "failures": 0,
+    "start": "2022-06-11T05:20:39.076Z",
+    "end": "2022-06-11T05:20:39.077Z",
+    "duration": 0,
+    "testsRegistered": 0,
+    "passPercent": null,
+    "pendingPercent": null,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false
+  },
+  "results": [
+    false
+  ],
+  "meta": {
+    "mocha": {
+      "version": "10.0.0"
+    },
+    "mochawesome": {
+      "options": {
+        "quiet": false,
+        "reportFilename": "mochawesome",
+        "saveHtml": true,
+        "saveJson": true,
+        "consoleReporter": "spec",
+        "useInlineDiffs": false,
+        "code": true
+      },
+      "version": "7.1.3"
+    },
+    "marge": {
+      "options": null,
+      "version": "6.2.0"
+    }
+  }
+}

--- a/tests/data/mocha/awesome/multiple-suites-multiple-tests.json
+++ b/tests/data/mocha/awesome/multiple-suites-multiple-tests.json
@@ -1,0 +1,162 @@
+{
+  "stats": {
+    "suites": 2,
+    "tests": 3,
+    "passes": 2,
+    "pending": 0,
+    "failures": 1,
+    "start": "2022-06-11T05:28:11.204Z",
+    "end": "2022-06-11T05:28:11.227Z",
+    "duration": 7,
+    "testsRegistered": 3,
+    "passPercent": 63.333,
+    "pendingPercent": 0,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false
+  },
+  "results": [
+    {
+      "uuid": "c3036d47-45a3-4c59-a114-fc90f4ad0532",
+      "title": "",
+      "fullFile": "",
+      "file": "",
+      "beforeHooks": [],
+      "afterHooks": [],
+      "tests": [],
+      "suites": [
+        {
+          "uuid": "544d6fcc-7849-4a32-aff8-b0be8e076fae",
+          "title": "Example Suite 1",
+          "fullFile": "",
+          "file": "",
+          "beforeHooks": [],
+          "afterHooks": [],
+          "tests": [
+            {
+              "title": "sample test case",
+              "fullTitle": "Example Suite 1 sample test case",
+              "timedOut": false,
+              "duration": 3,
+              "state": "passed",
+              "speed": "fast",
+              "pass": true,
+              "fail": false,
+              "pending": false,
+              "context": null,
+              "code": "",
+              "err": {},
+              "uuid": "47fa7bb9-a77f-43b3-abd0-59e2afa0ef0e",
+              "parentUUID": "544d6fcc-7849-4a32-aff8-b0be8e076fae",
+              "isHook": false,
+              "skipped": false
+            },
+            {
+              "title": "sample test case 2",
+              "fullTitle": "Example Suite 1 sample test case 2",
+              "timedOut": false,
+              "duration": 1,
+              "state": "passed",
+              "speed": "fast",
+              "pass": true,
+              "fail": false,
+              "pending": false,
+              "context": null,
+              "code": "",
+              "err": {},
+              "uuid": "14a946f8-b19e-43db-bc31-d75337ab55b3",
+              "parentUUID": "544d6fcc-7849-4a32-aff8-b0be8e076fae",
+              "isHook": false,
+              "skipped": false
+            }
+          ],
+          "suites": [],
+          "passes": [
+            "47fa7bb9-a77f-43b3-abd0-59e2afa0ef0e",
+            "14a946f8-b19e-43db-bc31-d75337ab55b3"
+          ],
+          "failures": [],
+          "pending": [],
+          "skipped": [],
+          "duration": 4,
+          "root": false,
+          "rootEmpty": false,
+          "_timeout": 2000
+        },
+        {
+          "uuid": "2fc0097a-29a4-4cc0-b045-007da8367164",
+          "title": "Example Suite 2",
+          "fullFile": "",
+          "file": "",
+          "beforeHooks": [],
+          "afterHooks": [],
+          "tests": [
+            {
+              "title": "sample test case",
+              "fullTitle": "Example Suite 2 sample test case",
+              "timedOut": false,
+              "duration": 1,
+              "state": "failed",
+              "speed": null,
+              "pass": false,
+              "fail": true,
+              "pending": false,
+              "context": null,
+              "code": "",
+              "err": {
+                "message": "Dummy reason",
+                "estack": "AssertionError [ERR_ASSERTION]: Dummy reason\n    at Context.<anonymous> (tests\\parser.mocha.json.spec.js:7:12)\n    at processImmediate (node:internal/timers:466:21)",
+                "diff": null
+              },
+              "uuid": "6bcc8efe-94ba-45c9-85cd-2cbe5ba777b1",
+              "parentUUID": "2fc0097a-29a4-4cc0-b045-007da8367164",
+              "isHook": false,
+              "skipped": false
+            }
+          ],
+          "suites": [],
+          "passes": [],
+          "failures": [
+            "6bcc8efe-94ba-45c9-85cd-2cbe5ba777b1"
+          ],
+          "pending": [],
+          "skipped": [],
+          "duration": 1,
+          "root": false,
+          "rootEmpty": false,
+          "_timeout": 2000
+        }
+      ],
+      "passes": [],
+      "failures": [],
+      "pending": [],
+      "skipped": [],
+      "duration": 0,
+      "root": true,
+      "rootEmpty": true,
+      "_timeout": 2000
+    }
+  ],
+  "meta": {
+    "mocha": {
+      "version": "10.0.0"
+    },
+    "mochawesome": {
+      "options": {
+        "quiet": false,
+        "reportFilename": "mochawesome",
+        "saveHtml": true,
+        "saveJson": true,
+        "consoleReporter": "spec",
+        "useInlineDiffs": false,
+        "code": true
+      },
+      "version": "7.1.3"
+    },
+    "marge": {
+      "options": null,
+      "version": "6.2.0"
+    }
+  }
+}

--- a/tests/data/mocha/awesome/single-suite-single-test.json
+++ b/tests/data/mocha/awesome/single-suite-single-test.json
@@ -1,0 +1,100 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 1,
+    "passes": 1,
+    "pending": 0,
+    "failures": 0,
+    "start": "2022-06-11T05:24:09.223Z",
+    "end": "2022-06-11T05:24:09.226Z",
+    "duration": 3,
+    "testsRegistered": 1,
+    "passPercent": 100,
+    "pendingPercent": 0,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false
+  },
+  "results": [
+    {
+      "uuid": "404f870c-75c7-47ef-91ad-cc2f2643d218",
+      "title": "",
+      "fullFile": "",
+      "file": "",
+      "beforeHooks": [],
+      "afterHooks": [],
+      "tests": [],
+      "suites": [
+        {
+          "uuid": "0d00a7c2-65a4-4667-93d1-58df2f209f59",
+          "title": "Simple Suite",
+          "fullFile": "",
+          "file": "",
+          "beforeHooks": [],
+          "afterHooks": [],
+          "tests": [
+            {
+              "title": "Simple suite test",
+              "fullTitle": "Simple Suite Simple suite test",
+              "timedOut": false,
+              "duration": 1,
+              "state": "passed",
+              "speed": "fast",
+              "pass": true,
+              "fail": false,
+              "pending": false,
+              "context": null,
+              "code": "",
+              "err": {},
+              "uuid": "cda8ce8d-3812-48b7-b7c3-0a04b8e431f9",
+              "parentUUID": "0d00a7c2-65a4-4667-93d1-58df2f209f59",
+              "isHook": false,
+              "skipped": false
+            }
+          ],
+          "suites": [],
+          "passes": [
+            "cda8ce8d-3812-48b7-b7c3-0a04b8e431f9"
+          ],
+          "failures": [],
+          "pending": [],
+          "skipped": [],
+          "duration": 1,
+          "root": false,
+          "rootEmpty": false,
+          "_timeout": 2000
+        }
+      ],
+      "passes": [],
+      "failures": [],
+      "pending": [],
+      "skipped": [],
+      "duration": 0,
+      "root": true,
+      "rootEmpty": true,
+      "_timeout": 2000
+    }
+  ],
+  "meta": {
+    "mocha": {
+      "version": "10.0.0"
+    },
+    "mochawesome": {
+      "options": {
+        "quiet": false,
+        "reportFilename": "mochawesome",
+        "saveHtml": true,
+        "saveJson": true,
+        "consoleReporter": "spec",
+        "useInlineDiffs": false,
+        "code": true
+      },
+      "version": "7.1.3"
+    },
+    "marge": {
+      "options": null,
+      "version": "6.2.0"
+    }
+  }
+}

--- a/tests/data/mocha/awesome/skipped-tests.json
+++ b/tests/data/mocha/awesome/skipped-tests.json
@@ -1,0 +1,120 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 2,
+    "passes": 1,
+    "pending": 1,
+    "failures": 0,
+    "start": "2022-06-11T08:23:09.912Z",
+    "end": "2022-06-11T08:23:09.915Z",
+    "duration": 3,
+    "testsRegistered": 2,
+    "passPercent": 100,
+    "pendingPercent": 50,
+    "other": 0,
+    "hasOther": false,
+    "skipped": 0,
+    "hasSkipped": false
+  },
+  "results": [
+    {
+      "uuid": "a3892a10-4d6a-4729-a479-4744cfb1f025",
+      "title": "",
+      "fullFile": "",
+      "file": "",
+      "beforeHooks": [],
+      "afterHooks": [],
+      "tests": [],
+      "suites": [
+        {
+          "uuid": "e450ecce-78d4-4013-8f88-5fa87007b564",
+          "title": "Example Suite",
+          "fullFile": "",
+          "file": "",
+          "beforeHooks": [],
+          "afterHooks": [],
+          "tests": [
+            {
+              "title": "first sample test",
+              "fullTitle": "Example Suite first sample test",
+              "timedOut": false,
+              "duration": 1,
+              "state": "passed",
+              "speed": "fast",
+              "pass": true,
+              "fail": false,
+              "pending": false,
+              "context": null,
+              "code": "",
+              "err": {},
+              "uuid": "5f4fc8ba-fbf0-4439-a084-4199ad46f812",
+              "parentUUID": "e450ecce-78d4-4013-8f88-5fa87007b564",
+              "isHook": false,
+              "skipped": false
+            },
+            {
+              "title": "second sample test",
+              "fullTitle": "Example Suite second sample test",
+              "timedOut": false,
+              "duration": 0,
+              "state": "pending",
+              "speed": null,
+              "pass": false,
+              "fail": false,
+              "pending": true,
+              "context": null,
+              "code": "",
+              "err": {},
+              "uuid": "9fc0d5f8-dc37-4139-b39f-9ca6e041aca3",
+              "parentUUID": "e450ecce-78d4-4013-8f88-5fa87007b564",
+              "isHook": false,
+              "skipped": false
+            }
+          ],
+          "suites": [],
+          "passes": [
+            "5f4fc8ba-fbf0-4439-a084-4199ad46f812"
+          ],
+          "failures": [],
+          "pending": [
+            "9fc0d5f8-dc37-4139-b39f-9ca6e041aca3"
+          ],
+          "skipped": [],
+          "duration": 1,
+          "root": false,
+          "rootEmpty": false,
+          "_timeout": 2000
+        }
+      ],
+      "passes": [],
+      "failures": [],
+      "pending": [],
+      "skipped": [],
+      "duration": 0,
+      "root": true,
+      "rootEmpty": true,
+      "_timeout": 2000
+    }
+  ],
+  "meta": {
+    "mocha": {
+      "version": "10.0.0"
+    },
+    "mochawesome": {
+      "options": {
+        "quiet": false,
+        "reportFilename": "mochawesome",
+        "saveHtml": true,
+        "saveJson": true,
+        "consoleReporter": "spec",
+        "useInlineDiffs": false,
+        "code": true
+      },
+      "version": "7.1.3"
+    },
+    "marge": {
+      "options": null,
+      "version": "6.2.0"
+    }
+  }
+}

--- a/tests/data/mocha/json/empty-suite.json
+++ b/tests/data/mocha/json/empty-suite.json
@@ -1,0 +1,16 @@
+{
+  "stats": {
+    "suites": 0,
+    "tests": 0,
+    "passes": 0,
+    "pending": 0,
+    "failures": 0,
+    "start": "2022-06-11T05:18:58.580Z",
+    "end": "2022-06-11T05:18:58.580Z",
+    "duration": 0
+  },
+  "tests": [],
+  "pending": [],
+  "failures": [],
+  "passes": []
+}

--- a/tests/data/mocha/json/multiple-suites-multiple-tests.json
+++ b/tests/data/mocha/json/multiple-suites-multiple-tests.json
@@ -1,0 +1,85 @@
+{
+  "stats": {
+    "suites": 2,
+    "tests": 3,
+    "passes": 2,
+    "pending": 0,
+    "failures": 1,
+    "start": "2022-06-11T05:28:11.204Z",
+    "end": "2022-06-11T05:28:11.227Z",
+    "duration": 7
+  },
+  "tests": [
+    {
+      "title": "sample test case",
+      "fullTitle": "Example Suite 1 sample test case",
+      "file": "",
+      "duration": 3,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case 2",
+      "fullTitle": "Example Suite 1 sample test case 2",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case",
+      "fullTitle": "Example Suite 2 sample test case",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "err": {
+        "stack": "AssertionError [ERR_ASSERTION]: Dummy reason\n    at Context.<anonymous> (tests\\parser.mocha.json.spec.js:7:12)\n    at processImmediate (node:internal/timers:466:21)",
+        "message": "Dummy reason",
+        "generatedMessage": false,
+        "name": "AssertionError",
+        "code": "ERR_ASSERTION",
+        "operator": "fail"
+      }
+    }
+  ],
+  "pending": [],
+  "failures": [
+    {
+      "title": "sample test case",
+      "fullTitle": "Example Suite 2 sample test case",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "err": {
+        "stack": "AssertionError [ERR_ASSERTION]: Dummy reason\n    at Context.<anonymous> (tests\\parser.mocha.json.spec.js:7:12)\n    at processImmediate (node:internal/timers:466:21)",
+        "message": "Dummy reason",
+        "generatedMessage": false,
+        "name": "AssertionError",
+        "code": "ERR_ASSERTION",
+        "operator": "fail"
+      }
+    }
+  ],
+  "passes": [
+    {
+      "title": "sample test case",
+      "fullTitle": "Example Suite 1 sample test case",
+      "file": "",
+      "duration": 3,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case 2",
+      "fullTitle": "Example Suite 1 sample test case 2",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ]
+}

--- a/tests/data/mocha/json/single-suite-single-test.json
+++ b/tests/data/mocha/json/single-suite-single-test.json
@@ -1,0 +1,36 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 1,
+    "passes": 1,
+    "pending": 0,
+    "failures": 0,
+    "start": "2022-06-11T05:24:09.223Z",
+    "end": "2022-06-11T05:24:09.226Z",
+    "duration": 3
+  },
+  "tests": [
+    {
+      "title": "Simple suite test",
+      "fullTitle": "Simple Suite Simple suite test",
+      "file": "D:\\tests\\test.mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ],
+  "pending": [],
+  "failures": [],
+  "passes": [
+    {
+      "title": "Simple suite test",
+      "fullTitle": "Simple Suite Simple suite test",
+      "file": "D:\\tests\\test.mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ]
+}

--- a/tests/data/mocha/json/skipped-tests.json
+++ b/tests/data/mocha/json/skipped-tests.json
@@ -1,0 +1,51 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 2,
+    "passes": 1,
+    "pending": 1,
+    "failures": 0,
+    "start": "2022-06-11T08:23:09.912Z",
+    "end": "2022-06-11T08:23:09.915Z",
+    "duration": 3
+  },
+  "tests": [
+    {
+      "title": "first sample test",
+      "fullTitle": "Example Suite first sample test",
+      "file": "D:\\git\\parser\\tests\\mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "second sample test",
+      "fullTitle": "Example Suite second sample test",
+      "file": "D:\\git\\parser\\tests\\mocha.spec.js",
+      "currentRetry": 0,
+      "err": {}
+    }
+  ],
+  "pending": [
+    {
+      "title": "second sample test",
+      "fullTitle": "Example Suite second sample test",
+      "file": "D:\\git\\parser\\tests\\mocha.spec.js",
+      "currentRetry": 0,
+      "err": {}
+    }
+  ],
+  "failures": [],
+  "passes": [
+    {
+      "title": "first sample test",
+      "fullTitle": "Example Suite first sample test",
+      "file": "D:\\git\\parser\\tests\\mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ]
+}

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -1,0 +1,416 @@
+const { parse } = require('../src');
+const assert = require('assert');
+
+describe('Parser - Mocha Json', () => {
+  const testDataPath = "tests/data/mocha/json"
+  it('single suite with single test', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/single-suite-single-test.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 1,
+      passed: 1,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 3000,
+      status: 'PASS',
+      suites: [
+        {
+          id: '',
+          name: 'Simple Suite',
+          total: 1,
+          passed: 1,
+          failed: 0,
+          errors: 0,
+          skipped: 0,
+          duration: 1000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "Simple suite test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+  it('empty suite report', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/empty-suite.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 0,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 0,
+      status: 'PASS',
+      suites: []
+    });
+  });
+  it('suite with skipped tests', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/skipped-tests.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 2,
+      passed: 1,
+      failed: 0,
+      errors: 0,
+      skipped: 1,
+      retried: 0,
+      duration: 3000,
+      status: 'PASS',
+      suites: [
+        {
+          id: '',
+          name: 'Example Suite',
+          total: 2,
+          passed: 1,
+          failed: 0,
+          errors: 0,
+          skipped: 1,
+          duration: 1000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "first sample test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            },
+            {
+              duration: 0,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "second sample test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "SKIP",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+  it('multiple suites', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 3,
+      passed: 2,
+      failed: 1,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 7000,
+      status: 'FAIL',
+      suites: [
+        {
+          id: '',
+          name: 'Example Suite 1',
+          total: 2,
+          passed: 2,
+          failed: 0,
+          errors: 0,
+          skipped: 0,
+          duration: 4000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 3000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "sample test case",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            },
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "sample test case 2",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            }
+          ]
+        },
+        {
+          id: '',
+          name: 'Example Suite 2',
+          total: 1,
+          passed: 0,
+          failed: 1,
+          errors: 0,
+          skipped: 0,
+          duration: 1000,
+          status: 'FAIL',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "Dummy reason",
+              id: "",
+              name: "sample test case",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "FAIL",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+});
+
+describe('Parser - Mocha Awesmome Json', () => {
+  const testDataPath = "tests/data/mocha/awesome"
+  it('single suite with single test', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/single-suite-single-test.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 1,
+      passed: 1,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 3000,
+      status: 'PASS',
+      suites: [
+        {
+          id: '',
+          name: 'Simple Suite',
+          total: 1,
+          passed: 1,
+          failed: 0,
+          errors: 0,
+          skipped: 0,
+          duration: 1000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "Simple suite test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+  it('empty suite report', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/empty-suite.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 0,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 0,
+      status: 'PASS',
+      suites: []
+    });
+  });
+  it('suite with skipped tests', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/skipped-tests.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 2,
+      passed: 1,
+      failed: 0,
+      errors: 0,
+      skipped: 1,
+      retried: 0,
+      duration: 3000,
+      status: 'PASS',
+      suites: [
+        {
+          id: '',
+          name: 'Example Suite',
+          total: 2,
+          passed: 1,
+          failed: 0,
+          errors: 0,
+          skipped: 1,
+          duration: 1000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "first sample test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            },
+            {
+              duration: 0,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "second sample test",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "SKIP",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+  it('multiple suites', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests.json`] });
+    assert.deepEqual(result, {
+      id: '',
+      name: '',
+      total: 3,
+      passed: 2,
+      failed: 1,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 7000,
+      status: 'FAIL',
+      suites: [
+        {
+          id: '',
+          name: 'Example Suite 1',
+          total: 2,
+          passed: 2,
+          failed: 0,
+          errors: 0,
+          skipped: 0,
+          duration: 4000,
+          status: 'PASS',
+          cases: [
+            {
+              duration: 3000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "sample test case",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            },
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "",
+              id: "",
+              name: "sample test case 2",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "PASS",
+              steps: [],
+              total: 0
+            }
+          ]
+        },
+        {
+          id: '',
+          name: 'Example Suite 2',
+          total: 1,
+          passed: 0,
+          failed: 1,
+          errors: 0,
+          skipped: 0,
+          duration: 1000,
+          status: 'FAIL',
+          cases: [
+            {
+              duration: 1000,
+              errors: 0,
+              failed: 0,
+              failure: "Dummy reason",
+              id: "",
+              name: "sample test case",
+              passed: 0,
+              skipped: 0,
+              stack_trace: "",
+              status: "FAIL",
+              steps: [],
+              total: 0
+            }
+          ]
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
closes #6 

Change Summary:
- Added `Mocha` JSON report parser.
  - Capable of parsing both default mocha `JSON` report and `mochawesome.json` report.
  - Adding formatting logic to format json report generated by default mocha JSON reporter to required format.
  - Easily digests `mochawesome.json` report.
- Added Tests for newly added mocha parser.
- Readme update