### PR TITLE
Address TypeError on XML with no tests - skip filter if there are no tests in the report

### DIFF
--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -91,7 +91,7 @@ function getTestResult(json) {
   result.passed = result.total - result.failed - result.errors;
   result.duration = rawResult["@_time"] * 1000;
   const rawSuites = rawResult["testsuite"];
-    if (!(typeof rawSuites === "undefined")) { // Don't filter if there are no testsuite objects
+  if (!(typeof rawSuites === "undefined")) { // Don't filter if there are no testsuite objects
     const filteredSuites = rawSuites.filter(suite => suite.testcase);
     for (let i = 0; i < filteredSuites.length; i++) {
       result.suites.push(getTestSuite(filteredSuites[i]));

--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -27,7 +27,7 @@ function getTestSuite(rawSuite) {
   suite.status = suite.total === suite.passed ? 'PASS' : 'FAIL';
   const raw_test_cases = rawSuite.testcase;
   if (raw_test_cases) {
-    for(let i = 0; i < raw_test_cases.length; i++) {
+    for (let i = 0; i < raw_test_cases.length; i++) {
       suite.cases.push(getTestCase(raw_test_cases[i]));
     }
   }
@@ -76,10 +76,12 @@ function getTestResult(json) {
   result.total = result.total - result.skipped;
   result.passed = result.total - result.failed - result.errors;
   result.duration = rawResult["@_time"] * 1000;
-  const rawSuites = rawResult["testsuite"];
-  const filteredSuites = rawSuites.filter(suite => suite.testcase);
-  for (let i = 0; i < filteredSuites.length; i++) {
-    result.suites.push(getTestSuite(filteredSuites[i]));
+  if (result.total > 0 && result.skpped == 0) { // Don't filter if there are no tests
+    const rawSuites = rawResult["testsuite"];
+    const filteredSuites = rawSuites.filter(suite => suite.testcase);
+    for (let i = 0; i < filteredSuites.length; i++) {
+      result.suites.push(getTestSuite(filteredSuites[i]));
+    }
   }
   setAggregateResults(result);
   result.status = result.total === result.passed ? 'PASS' : 'FAIL';

--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -76,7 +76,7 @@ function getTestResult(json) {
   result.total = result.total - result.skipped;
   result.passed = result.total - result.failed - result.errors;
   result.duration = rawResult["@_time"] * 1000;
-  if (result.total > 0 && result.skpped == 0) { // Don't filter if there are no tests
+  if (result.total > 0 || result.skipped > 0) { // Don't filter if there are no tests
     const rawSuites = rawResult["testsuite"];
     const filteredSuites = rawSuites.filter(suite => suite.testcase);
     for (let i = 0; i < filteredSuites.length; i++) {

--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -90,8 +90,8 @@ function getTestResult(json) {
   result.total = result.total - result.skipped;
   result.passed = result.total - result.failed - result.errors;
   result.duration = rawResult["@_time"] * 1000;
-  if (result.total > 0 || result.skipped > 0) { // Don't filter if there are no tests
-    const rawSuites = rawResult["testsuite"];
+  const rawSuites = rawResult["testsuite"];
+    if (!(typeof rawSuites === "undefined")) { // Don't filter if there are no testsuite objects
     const filteredSuites = rawSuites.filter(suite => suite.testcase);
     for (let i = 0; i < filteredSuites.length; i++) {
       result.suites.push(getTestSuite(filteredSuites[i]));

--- a/tests/data/junit/no-suites.xml
+++ b/tests/data/junit/no-suites.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<testsuites id="id" name="no suites" tests="0" failures="0"  time="0">
+</testsuites>

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -414,4 +414,21 @@ describe('Parser - JUnit', () => {
     });
   });
 
+  it('empty suite with no tests', () => {
+    const result = parse({ type: 'junit', files: ['tests/data/junit/no-suites.xml'] });
+    assert.deepEqual(result, {
+      id: '',
+      name: 'no suites',
+      total: 0,
+      passed: 0,
+      failed: 0,
+      errors: 0,
+      skipped: 0,
+      retried: 0,
+      duration: 0,
+      status: 'PASS',
+      suites: []
+    });
+  });
+
 });


### PR DESCRIPTION
Fixes error parsing results files if an XML has no tests. When running multiple tests the Cypress framework can output an empty XML alongside the XMLs for each suite.  Error is: 

```
TypeError: Cannot read properties of undefined (reading 'filter')
    at getTestResult (/home/runner/work/cypress-tests/cypress-tests/node_modules/test-results-parser/src/parsers/junit.js:80:36)
    at Object.parse (/home/runner/work/cypress-tests/cypress-tests/node_modules/test-results-parser/src/parsers/junit.js:91:10)
...
```

When parsing an XML that looks like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="Cypress Tests 2022-10-13T19:34:52.973Z" time="0.0000" tests="0" failures="0">
</testsuites>
```

Fix skips filtering on the XML if there are no tests present.  