### PR TITLE
provide junit duration aggregation

### DIFF
--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -44,18 +44,23 @@ function setAggregateResults(result) {
     let failed = 0;
     let errors = 0;
     let skipped = 0;
+    let duration = 0;
     result.suites.forEach(_suite => {
       total = _suite.total + total;
       passed = _suite.passed + passed;
       failed = _suite.failed + failed;
       errors = _suite.errors + errors;
       skipped = _suite.skipped + skipped;
+      duration = _suite.duration + duration;
     });
     result.passed = passed;
     result.failed = failed;
     result.errors = errors;
     result.skipped = skipped;
     result.total = total;
+    if (Number.isNaN(result.duration)) {
+      result.duration = duration;
+    }
   }
 }
 


### PR DESCRIPTION
junit parser script made the assumption that duration is include in parent xml's testsuites attributes, but this not the case for "dotnet test" [unit.testlogger](https://github.com/spekt/junit.testlogger).

parent testsuites has not attribute at all. This lead to the following exception.

```
TypeError: Expected a finite number
    at /snapshot/mnt/node_modules/pretty-ms/index.js:10:9
    at getPrettyDuration (/snapshot/mnt/src/helpers/helper.js:58:10)
    at setMainBlock (/snapshot/mnt/src/targets/slack.js:59:28)
    at setFunctionalPayload (/snapshot/mnt/src/targets/slack.js:34:3)
    at process.runNextTicks [as _tickCallback] (node:internal/process/task_queues:60:5)
    at Function.runMain (pkg/prelude/bootstrap.js:1984:13)
    at node:internal/main/run_main_module:17:47
    at async Object.run (/snapshot/mnt/src/targets/slack.js:23:5)
    at async Object.run (/snapshot/mnt/src/targets/index.js:30:5)
    at async Object.run (/snapshot/mnt/src/commands/publish.js:31:9)
```

JUnit Logger XML Sample

```
<testsuites>
  <testsuite name="mytests" tests="92" skipped="0" failures="0" errors="0" time="0.8236604" timestamp="2022-10-20T07:53:09" id="0">
...
  </testsuite>
</testsuites>
```