### PR TITLE
Add metadata to TestCase

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   "devDependencies": {
     "c8": "^7.12.0",
     "mocha": "^10.0.0"
+  },
+  "mocha": {
+    "spec": "tests/**/*.spec.js"
   }
 }

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -22,6 +22,7 @@ const FORCED_ARRAY_KEYS = [
   "assemblies.assembly.collection",
   "assemblies.assembly.collection.test",
   "assemblies.assembly.collection.test.failure",
+  "assemblies.assembly.collection.test.traits.trait",
   "testng-results",
   "testng-results.suite",
   "testng-results.suite.test",

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -17,6 +17,7 @@ const FORCED_ARRAY_KEYS = [
   "testsuites.testsuite",
   "testsuites.testsuite.testcase",
   "testsuites.testsuite.testcase.failure",
+  "testsuites.testsuite.testcase.properties.property",
   "assemblies",
   "assemblies.assembly",
   "assemblies.assembly.collection",

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -26,6 +26,8 @@ const FORCED_ARRAY_KEYS = [
   "assemblies.assembly.collection.test.traits.trait",
   "testng-results",
   "testng-results.suite",
+  "testng-results.suite.groups.group",
+  "testng-results.suite.groups.group.method",
   "testng-results.suite.test",
   "testng-results.suite.test.class",
   "testng-results.suite.test.class.test-method",

--- a/src/models/TestCase.d.ts
+++ b/src/models/TestCase.d.ts
@@ -12,6 +12,7 @@ declare class TestCase {
   failure: string;
   stack_trace: string;
   steps: TestStep[];
+  meta_data: Map<string,string>;
 }
 
 declare namespace TestCase { }

--- a/src/models/TestCase.js
+++ b/src/models/TestCase.js
@@ -13,6 +13,7 @@ class TestCase {
       this.failure = '';
       this.stack_trace = '';
       this.steps = [];
+      this.meta_data = new Map();
     }
   
   }

--- a/src/parsers/cucumber.js
+++ b/src/parsers/cucumber.js
@@ -12,14 +12,19 @@ function getTestCase(rawCase) {
   test_case.name = rawCase["name"];
   test_case.duration = rawCase["duration"];
   if (rawCase.tags && rawCase.tags.length > 0) {
-    const rawtags = rawCase.tags;
+    const tagsArray = rawCase.tags;
     let tags = [];
-    for (let i = 0; i < rawtags.length; i++) {
-      let tagName = rawtags[i]["name"];
-      test_case.meta_data.set(tagName, rawtags[i]["line"])
+    let rawTags = [];
+    for (let i = 0; i < tagsArray.length; i++) {
+      let rawTagName = tagsArray[i]["name"];
+      let tag = rawTagName.substring(1).split("=");
+      let tagName = tag[0];
+      test_case.meta_data.set(tagName, tag[1] ?? "")
       tags.push(tagName);
+      rawTags.push(rawTagName);
     }
     test_case.meta_data.set("tags", tags.join(","));
+    test_case.meta_data.set("tagsRaw", rawTags.join(","));
   }
   if (rawCase.state && rawCase.state === "failed") {
     test_case.status = 'FAIL';

--- a/src/parsers/cucumber.js
+++ b/src/parsers/cucumber.js
@@ -11,6 +11,16 @@ function getTestCase(rawCase) {
   const test_case = new TestCase();
   test_case.name = rawCase["name"];
   test_case.duration = rawCase["duration"];
+  if (rawCase.tags && rawCase.tags.length > 0) {
+    const rawtags = rawCase.tags;
+    let tags = [];
+    for (let i = 0; i < rawtags.length; i++) {
+      let tagName = rawtags[i]["name"];
+      test_case.meta_data.set(tagName, rawtags[i]["line"])
+      tags.push(tagName);
+    }
+    test_case.meta_data.set("tags", tags.join(","));
+  }
   if (rawCase.state && rawCase.state === "failed") {
     test_case.status = 'FAIL';
     test_case.failure = rawCase.errorStack;

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -11,6 +11,17 @@ function getTestCase(rawCase) {
   const test_case = new TestCase();
   test_case.name = rawCase["title"];
   test_case.duration = rawCase["duration"];
+  const regexp = /([\@\#][^\s]*)/gm; // match @tag or #tag
+  let matches = [...test_case.name.matchAll(regexp)];
+  if (matches.length > 0) {
+    let tags = []
+    for (let match of matches) {
+      let tagName = match[0];
+      test_case.meta_data.set(tagName, "");
+      tags.push(tagName);
+    }
+    test_case.meta_data.set("tags", tags.join(","));
+  }
   if (rawCase["state"] == "pending") {
     test_case.status = 'SKIP';
   }

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -14,13 +14,18 @@ function getTestCase(rawCase) {
   const regexp = /([\@\#][^\s]*)/gm; // match @tag or #tag
   let matches = [...test_case.name.matchAll(regexp)];
   if (matches.length > 0) {
-    let tags = []
+    let tags = [];
+    let rawTags = [];
     for (let match of matches) {
-      let tagName = match[0];
-      test_case.meta_data.set(tagName, "");
+      let rawTag = match[0];
+      let tag  = rawTag.substring(1).split("=");
+      let tagName = tag[0];
+      test_case.meta_data.set(tagName, tag[1] ?? "");
       tags.push(tagName);
+      rawTags.push(rawTag);
     }
     test_case.meta_data.set("tags", tags.join(","));
+    test_case.meta_data.set("tagsRaw", rawTags.join(","));
   }
   if (rawCase["state"] == "pending") {
     test_case.status = 'SKIP';

--- a/src/parsers/xunit.js
+++ b/src/parsers/xunit.js
@@ -19,6 +19,13 @@ function getTestCase(rawCase) {
   else {
     test_case.status = 'PASS';
   }
+  if(rawCase.traits && rawCase.traits.trait && rawCase.traits.trait.length > 0) {
+    const traits = rawCase.traits.trait;
+    for(let i = 0; i < traits.length; i++) {
+      test_case.meta_data.set( traits[i]["@_name"], traits[i]["@_value"]);
+    }
+  }
+
   return test_case;
 }
 

--- a/tests/data/cucumber/single-suite-single-test.json
+++ b/tests/data/cucumber/single-suite-single-test.json
@@ -57,6 +57,10 @@
           {
             "name": "@fast",
             "line": 4
+          },
+          {
+            "name": "@testCase=1234",
+            "line": 4
           }
         ],
         "type": "scenario"

--- a/tests/data/cucumber/single-suite-single-test.json
+++ b/tests/data/cucumber/single-suite-single-test.json
@@ -53,6 +53,10 @@
           {
             "name": "@green",
             "line": 4
+          },
+          {
+            "name": "@fast",
+            "line": 4
           }
         ],
         "type": "scenario"

--- a/tests/data/junit/multiple-suites-properties.xml
+++ b/tests/data/junit/multiple-suites-properties.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<testsuites id="id" name="result name" tests="2" failures="1" errors="" time="20">
+    <testsuite id="codereview.cobol.analysisProvider" name="suite name 1" tests="1" failures="1" time="10">
+        <properties>
+          <property name="key1" value="value1" />
+          <property name="key2" value="value2" />
+        </properties>
+        <testcase id="codereview.cobol.rules.ProgramIdRule" name="Use a program name that matches the source file name" time="10">
+            <properties>
+                <property name="key1" value="override-value1" />
+            </properties>
+            <failure message="PROGRAM.cbl:2 Use a program name that matches the source file name" type="WARNING">
+                Some Text
+            </failure>
+        </testcase>
+    </testsuite>
+    <testsuite id="codereview.cobol.analysisProvider" name="suite name 2" tests="1" failures="0" time="10">
+        <testcase id="codereview.cobol.rules.ProgramIdRule" name="Use a program name that matches the source file name" time="10">
+            <failure message="PROGRAM.cbl:2 Use a program name that matches the source file name" type="WARNING">
+                Some Text
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/data/mocha/json/multiple-suites-multiple-tests-tags.json
+++ b/tests/data/mocha/json/multiple-suites-multiple-tests-tags.json
@@ -1,0 +1,85 @@
+{
+  "stats": {
+    "suites": 2,
+    "tests": 3,
+    "passes": 2,
+    "pending": 0,
+    "failures": 1,
+    "start": "2022-06-11T05:28:11.204Z",
+    "end": "2022-06-11T05:28:11.227Z",
+    "duration": 7
+  },
+  "tests": [
+    {
+      "title": "sample test case @fast #1255",
+      "fullTitle": "Example Suite 1 sample test case @fast #1255",
+      "file": "",
+      "duration": 3,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case 2",
+      "fullTitle": "Example Suite 1 sample test case 2",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case #1234",
+      "fullTitle": "Example Suite 2 sample test case #1234",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "err": {
+        "stack": "AssertionError [ERR_ASSERTION]: Dummy reason\n    at Context.<anonymous> (tests\\parser.mocha.json.spec.js:7:12)\n    at processImmediate (node:internal/timers:466:21)",
+        "message": "Dummy reason",
+        "generatedMessage": false,
+        "name": "AssertionError",
+        "code": "ERR_ASSERTION",
+        "operator": "fail"
+      }
+    }
+  ],
+  "pending": [],
+  "failures": [
+    {
+      "title": "sample test case #1234",
+      "fullTitle": "Example Suite 2 sample test case #1234",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "err": {
+        "stack": "AssertionError [ERR_ASSERTION]: Dummy reason\n    at Context.<anonymous> (tests\\parser.mocha.json.spec.js:7:12)\n    at processImmediate (node:internal/timers:466:21)",
+        "message": "Dummy reason",
+        "generatedMessage": false,
+        "name": "AssertionError",
+        "code": "ERR_ASSERTION",
+        "operator": "fail"
+      }
+    }
+  ],
+  "passes": [
+    {
+      "title": "sample test case @fast #1255",
+      "fullTitle": "Example Suite 1 sample test case @fast #1255",
+      "file": "",
+      "duration": 3,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    },
+    {
+      "title": "sample test case 2",
+      "fullTitle": "Example Suite 1 sample test case 2",
+      "file": "",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ]
+}

--- a/tests/data/testng/groups.xml
+++ b/tests/data/testng/groups.xml
@@ -1,0 +1,36 @@
+<testng-results>
+  <suite name="Suite1" duration-ms="2000">
+    <groups>
+      <group name="group1">
+        <method signature="com.test.TestOne.test2()" name="test2" class="com.test.TestOne"/>
+        <method signature="com.test.TestOne.test1()" name="test1" class="com.test.TestOne"/>
+      </group>
+      <group name="group2">
+        <method signature="com.test.TestOne.test2()" name="test2" class="com.test.TestOne"/>
+      </group>
+    </groups>
+    <test name="test1">
+      <class name="com.test.TestOne">
+        <test-method status="FAIL" signature="test1()" name="test1" duration-ms="11"
+              started-at="2007-05-28T12:14:37Z" description="someDescription2"
+              finished-at="2007-05-28T12:14:37Z">
+          <exception class="java.lang.AssertionError">
+            <short-stacktrace>
+              <![CDATA[
+                java.lang.AssertionError
+                ... Removed 22 stack frames
+              ]]>
+            </short-stacktrace>
+          </exception>
+        </test-method>
+        <test-method status="PASS" signature="test2()" name="test2" duration-ms="11"
+              started-at="2007-05-28T12:14:37Z" description="someDescription1"
+              finished-at="2007-05-28T12:14:37Z">
+        </test-method>
+        <test-method status="PASS" signature="setUp()" name="setUp" is-config="true" duration-ms="15"
+              started-at="2007-05-28T12:14:37Z" finished-at="2007-05-28T12:14:37Z">
+        </test-method>
+      </class>
+    </test>
+  </suite>
+</testng-results>

--- a/tests/data/xunit/multiple-suites.xml
+++ b/tests/data/xunit/multiple-suites.xml
@@ -55,7 +55,6 @@
         <output>Test output</output>
         <traits>
           <trait name="TestID" value="RTA-21538" />
-          <trait name="TestLevel" value="ReadOnly" />
           <trait name="TestLevel" value="Regression" />
           <trait name="TestProduct" value="ExampleTestProduct" />
           <trait name="TestSuite" value="ExampleTestSuite" />

--- a/tests/data/xunit/no-traits-suite.xml
+++ b/tests/data/xunit/no-traits-suite.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assemblies timestamp="07/21/2021 08:26:30">
+  <assembly name="single suite test " run-date="2021-07-21" run-time="08:26:30" total="1" passed="0" failed="1" skipped="0" time="86.0065" errors="0">
+    <errors />
+    <collection total="1" passed="0" failed="1" skipped="0" name="Example test collection 1" time="86.0065">
+      <test name="Example test case 1" type="Example test" method="Example Method" time="86.0065" result="Fail">
+        <output>Test link information</output>
+        <failure>
+          <message>Example of a failure message</message>
+          <stack-trace>Long string with failure
+          </stack-trace>
+        </failure>
+      </test>
+    </collection>
+  
+  </assembly>
+
+</assemblies>

--- a/tests/data/xunit/skipped-suite.xml
+++ b/tests/data/xunit/skipped-suite.xml
@@ -8,11 +8,6 @@
 </output>
         <traits>
           <trait name="UnsupportedEnvirnoment" value="uat" />
-          <trait name="TestID" value="RTA-TESTID" />
-          <trait name="BSIdentifier" value="BS-2650" />
-          <trait name="TestLevel" value="Smoke" />
-          <trait name="TestProduct" value="FakeProduct" />
-          <trait name="TestSuite" value="skippable" />
         </traits>
       </test>
     </collection>

--- a/tests/parser.cucumber.spec.js
+++ b/tests/parser.cucumber.spec.js
@@ -40,6 +40,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -102,6 +103,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -116,6 +118,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -143,6 +146,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }

--- a/tests/parser.cucumber.spec.js
+++ b/tests/parser.cucumber.spec.js
@@ -40,7 +40,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
-              meta_data: newMap({tags:"@green,@fast", "@green":4, "@fast":4}),
+              meta_data: newMap({tags:"green,fast,testCase", green: "", fast: "", testCase: "1234", tagsRaw:"@green,@fast,@testCase=1234"}),
               steps: [],
               total: 0
             }

--- a/tests/parser.cucumber.spec.js
+++ b/tests/parser.cucumber.spec.js
@@ -40,7 +40,7 @@ describe('Parser - Cucumber Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
-              meta_data: new Map(),
+              meta_data: newMap({tags:"@green,@fast", "@green":4, "@fast":4}),
               steps: [],
               total: 0
             }
@@ -164,5 +164,13 @@ describe('Parser - Cucumber Json', () => {
     const result2 = parse({ type: 'cucumber', files: [ relativePath]});
     assert.notEqual(null, result2);
   });
+  
+  function newMap( obj ) {
+    let map = new Map();
+    for (const property in obj) {
+      map.set( property, obj[property]);
+    }
+    return map;
+  }
 });
 

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -40,6 +40,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -85,6 +86,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -130,6 +132,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -175,6 +178,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -202,6 +206,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -247,6 +252,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -274,6 +280,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -319,6 +326,7 @@ describe('Parser - JUnit', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -365,6 +373,7 @@ describe('Parser - JUnit', () => {
               "status": "FAIL",
               "failure": "expected to include 'Residntial'",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -379,6 +388,7 @@ describe('Parser - JUnit', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -406,6 +416,7 @@ describe('Parser - JUnit', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -451,6 +462,7 @@ describe('Parser - JUnit', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -465,6 +477,7 @@ describe('Parser - JUnit', () => {
               "status": "FAIL",
               "failure": "TearDown : System.InvalidOperationException : Operation is not valid due to the current state of the object.",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -479,6 +492,7 @@ describe('Parser - JUnit', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -493,6 +507,7 @@ describe('Parser - JUnit', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -541,4 +541,11 @@ describe('Parser - JUnit', () => {
     const result2 = parse({ type: 'junit', files: [relativePath]});
     assert.notEqual(null, result2);
   });
+  
+  it('meta-data from suite copied to testcase', () => {
+    const result = parse({ type: 'junit', files: ['tests/data/junit/multiple-suites-properties.xml'] });
+    assert.equal(result.suites[0].cases[0].meta_data.size, 2);
+    assert.equal(result.suites[0].cases[0].meta_data.get("key1"), "override-value1");
+  });
+
 });

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -213,6 +213,7 @@ describe('Parser - Mocha Json', () => {
       ]
     });
   });
+
   it('can support absolute and relative file paths', () => {
     let relativePath = `${testDataPath}/single-suite-single-test.json`;
     let absolutePath = path.resolve(relativePath);
@@ -220,6 +221,29 @@ describe('Parser - Mocha Json', () => {
     assert.notEqual(null, result1);
     const result2 = parse({ type: 'mocha', files: [relativePath]});
     assert.notEqual(null, result2);
+  });
+
+  it('has multiple tags', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests-tags.json`] });
+    let testcase = result.suites[0].cases[0];
+    assert.equal(testcase.meta_data.has("tags"), true);
+    assert.equal(testcase.meta_data.get("tags"), "@fast,#1255")
+    assert.equal(testcase.meta_data.has("@fast"), true);
+    assert.equal(testcase.meta_data.has("#1255"), true);
+  });
+
+  it('has single tag', () => {
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests-tags.json`] });
+    let testcase = result.suites[1].cases[0];
+    assert.equal(testcase.meta_data.has("tags"), true);
+    assert.equal(testcase.meta_data.get("tags"), "#1234")
+    assert.equal(testcase.meta_data.has("#1234"), true);
+  });
+
+  it('does not include tags meta if no tags are present', () =>{
+    const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests-tags.json`] });
+    let testcase = result.suites[0].cases[1];
+    assert.equal(testcase.meta_data.has("tags"), false);
   });
 });
 

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -227,17 +227,19 @@ describe('Parser - Mocha Json', () => {
     const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests-tags.json`] });
     let testcase = result.suites[0].cases[0];
     assert.equal(testcase.meta_data.has("tags"), true);
-    assert.equal(testcase.meta_data.get("tags"), "@fast,#1255")
-    assert.equal(testcase.meta_data.has("@fast"), true);
-    assert.equal(testcase.meta_data.has("#1255"), true);
+    assert.equal(testcase.meta_data.get("tags"), "fast,1255")
+    assert.equal(testcase.meta_data.get("tagsRaw"), "@fast,#1255")
+    assert.equal(testcase.meta_data.has("fast"), true);
+    assert.equal(testcase.meta_data.has("1255"), true);
   });
 
   it('has single tag', () => {
     const result = parse({ type: 'mocha', files: [`${testDataPath}/multiple-suites-multiple-tests-tags.json`] });
     let testcase = result.suites[1].cases[0];
     assert.equal(testcase.meta_data.has("tags"), true);
-    assert.equal(testcase.meta_data.get("tags"), "#1234")
-    assert.equal(testcase.meta_data.has("#1234"), true);
+    assert.equal(testcase.meta_data.get("tags"), "1234")
+    assert.equal(testcase.meta_data.get("tagsRaw"), "#1234")
+    assert.equal(testcase.meta_data.has("1234"), true);
   });
 
   it('does not include tags meta if no tags are present', () =>{

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -40,6 +40,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -100,6 +101,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -114,6 +116,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "SKIP",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -158,6 +161,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -172,6 +176,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -199,6 +204,7 @@ describe('Parser - Mocha Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -255,6 +261,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -315,6 +322,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -329,6 +337,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "SKIP",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -373,6 +382,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -387,6 +397,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -414,6 +425,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -458,6 +470,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             },
@@ -472,6 +485,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "PASS",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }
@@ -499,6 +513,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               skipped: 0,
               stack_trace: "",
               status: "FAIL",
+              meta_data: new Map(),
               steps: [],
               total: 0
             }

--- a/tests/parser.testng.spec.js
+++ b/tests/parser.testng.spec.js
@@ -1001,4 +1001,13 @@ describe('Parser - TestNG', () => {
     assert.notEqual(null, result2);
   });
 
+  it('assign groups to testcases in single suite', () => {
+    const result = parse({ type: 'testng', files: ['tests/data/testng/groups.xml'] });
+    assert.equal(result.suites[0].cases[0].meta_data.get("groups"), "group1");
+    assert.equal(result.suites[0].cases[0].meta_data.has("group1"), true);
+    // 2nd testcase has multiple groups
+    assert.equal(result.suites[0].cases[1].meta_data.get("groups"), "group1,group2");
+    assert.equal(result.suites[0].cases[1].meta_data.has("group1"), true);
+    assert.equal(result.suites[0].cases[1].meta_data.has("group2"), true);
+  });
 });

--- a/tests/parser.testng.spec.js
+++ b/tests/parser.testng.spec.js
@@ -41,6 +41,7 @@ describe('Parser - TestNG', () => {
               status: 'PASS',
               failure: '',
               stack_trace: '',
+              meta_data: new Map(),
               steps: []
             },
             {
@@ -55,6 +56,7 @@ describe('Parser - TestNG', () => {
               status: 'PASS',
               failure: '',
               stack_trace: '',
+              meta_data: new Map(),
               steps: []
             },
             {
@@ -69,6 +71,7 @@ describe('Parser - TestNG', () => {
               status: 'PASS',
               failure: '',
               stack_trace: '',
+              meta_data: new Map(),
               steps: []
             },
             {
@@ -83,6 +86,7 @@ describe('Parser - TestNG', () => {
               status: 'PASS',
               failure: 'expected [true] but found [false]',
               stack_trace: '',
+              meta_data: new Map(),
               steps: []
             }
           ]
@@ -128,6 +132,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "expected [A] but found [948474]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -142,6 +147,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -156,6 +162,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -170,6 +177,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "Expected condition failed: : 95ddbda01ea4b3dbcb049e681a6...}",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -184,6 +192,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "element click intercepted:",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -211,6 +220,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "expected [A] but found [948474]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -225,6 +235,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -239,6 +250,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -253,6 +265,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "Appium error: An unknown sr='Search...']}",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -267,6 +280,7 @@ describe('Parser - TestNG', () => {
               "status": "SKIP",
               "failure": "A script did not complete ",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -312,6 +326,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -326,6 +341,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -340,6 +356,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -354,6 +371,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "expected [true] but found [false]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -399,6 +417,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -413,6 +432,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -427,6 +447,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -441,6 +462,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "expected [true] but found [false]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -468,6 +490,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -482,6 +505,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -496,6 +520,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -510,6 +535,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "expected [true] but found [false]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -555,6 +581,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -569,6 +596,7 @@ describe('Parser - TestNG', () => {
               "status": "RETRY",
               "failure": "failed",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -583,6 +611,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "failed",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -597,6 +626,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -624,6 +654,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -638,6 +669,7 @@ describe('Parser - TestNG', () => {
               "status": "RETRY",
               "failure": "failed",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -652,6 +684,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "failed",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -666,6 +699,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -711,6 +745,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "expected [A] but found [948474]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -725,6 +760,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -739,6 +775,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -753,6 +790,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "Expected condition failed: : 95ddbda01ea4b3dbcb049e681a6...}",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -767,6 +805,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "element click intercepted:",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -794,6 +833,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "expected [A] but found [948474]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -808,6 +848,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -822,6 +863,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -836,6 +878,7 @@ describe('Parser - TestNG', () => {
               "status": "FAIL",
               "failure": "Appium error: An unknown sr='Search...']}",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -850,6 +893,7 @@ describe('Parser - TestNG', () => {
               "status": "SKIP",
               "failure": "A script did not complete ",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]
@@ -877,6 +921,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -891,6 +936,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -905,6 +951,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             },
             {
@@ -919,6 +966,7 @@ describe('Parser - TestNG', () => {
               "status": "PASS",
               "failure": "expected [true] but found [false]",
               "stack_trace": "",
+              "meta_data": new Map(),
               "steps": []
             }
           ]

--- a/tests/parser.xunit.spec.js
+++ b/tests/parser.xunit.spec.js
@@ -43,6 +43,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "FAIL",
               steps: [],
+              meta_data: newMap({ TestID: "ID", TestLevel: "Regression", TestProduct: "TestProductExample", TestSuite: "TestSuiteExample"}),
               total: 0
             }
           ]
@@ -87,6 +88,7 @@ describe('Parser - XUnit', () => {
             stack_trace: "",
             status: "SKIP",
             steps: [],
+            meta_data: newMap({ UnsupportedEnvirnoment: "uat"}),
             total: 0
           }]
         }
@@ -130,6 +132,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "FAIL",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-21505", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             },
             {
@@ -144,6 +147,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "PASS",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-21510", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             }
           ]
@@ -171,6 +175,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "FAIL",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-21516", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             },   
             {
@@ -185,6 +190,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "PASS",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-21513", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             }
           ]
@@ -212,6 +218,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "PASS",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-21538", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             }
           ]
@@ -239,6 +246,7 @@ describe('Parser - XUnit', () => {
               stack_trace: "",
               status: "FAIL",
               steps: [],
+              meta_data: newMap({ TestID: "RTA-37684", TestLevel: "Regression", TestProduct: "ExampleTestProduct", TestSuite: "ExampleTestSuite"}),
               total: 0
             }
           ]
@@ -256,4 +264,22 @@ describe('Parser - XUnit', () => {
     const result2 = parse({ type: 'xunit', files: [relativePath]});
     assert.notEqual(null, result2);
   });
+
+  it('meta-data from traits', () => {
+    const result = parse({ type: 'xunit', files: ['tests/data/xunit/single-suite.xml'] });
+    assert.equal(result.suites[0].cases[0].meta_data.size, 4);
+  });
+  
+  it('no meta-data from empty traits', () => {
+    const result = parse({ type: 'xunit', files: ['tests/data/xunit/no-traits-suite.xml'] });
+    assert.equal(result.suites[0].cases[0].meta_data.size, 0);
+  })
+
+  function newMap( obj ) {
+    let map = new Map();
+    for (const property in obj) {
+      map.set( property, obj[property]);
+    }
+    return map;
+  }
 });


### PR DESCRIPTION
This PR introduces a meta_data property to TestCase as outlined in proposal #34 

All existing unit tests have been updated to support the new property.

- [x] Cucumber implementation
- [x] jUnit implementation
- [x] Mocha implementation
- [x] TestNG implementation
- [x] xUnit implementation


