### PR TITLE
fix for absolute and relative paths

### DIFF
--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -40,9 +40,13 @@ const configured_parser = new XMLParser({
   parseAttributeValue: true,
 });
 
-function getJsonFromXMLFile(filePath) {
+function resolveFilePath(filePath) {
   const cwd = process.cwd();
-  const xml = fs.readFileSync(path.join(cwd, filePath)).toString();
+  return path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+}
+
+function getJsonFromXMLFile(filePath) {
+  const xml = fs.readFileSync(resolveFilePath(filePath)).toString();
   return configured_parser.parse(xml);
 }
 
@@ -67,5 +71,6 @@ function getMatchingFilePaths(file_path) {
 
 module.exports = {
   getJsonFromXMLFile,
-  getMatchingFilePaths
+  getMatchingFilePaths,
+  resolveFilePath
 }

--- a/src/parsers/cucumber.js
+++ b/src/parsers/cucumber.js
@@ -1,7 +1,7 @@
 /*
 *  Parser for both Mocha Json report and Mochawesome json
 */
-const path = require('path');
+const { resolveFilePath } = require('../helpers/helper');
 
 const TestResult = require('../models/TestResult');
 const TestSuite = require('../models/TestSuite');
@@ -93,8 +93,7 @@ function preprocess(rawjson) {
 }
 
 function parse(file) {
-  const cwd = process.cwd();
-  const json = require(path.join(cwd, file));
+  const json = require(resolveFilePath(file));
   return getTestResult(json);
 } 
 

--- a/src/parsers/mocha.js
+++ b/src/parsers/mocha.js
@@ -1,7 +1,7 @@
 /*
 *  Parser for both Mocha Json report and Mochawesome json
 */
-const path = require('path');
+const { resolveFilePath } = require('../helpers/helper');
 
 const TestResult = require('../models/TestResult');
 const TestSuite = require('../models/TestSuite');
@@ -136,8 +136,7 @@ function flattenTestSuite(suite) {
 
 
 function parse(file) {
-  const cwd = process.cwd();
-  const json = require(path.join(cwd, file));
+  const json = require(resolveFilePath(file));
   return getTestResult(json);
 }
 

--- a/tests/parser.cucumber.spec.js
+++ b/tests/parser.cucumber.spec.js
@@ -1,5 +1,6 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - Cucumber Json', () => {
   const testDataPath = "tests/data/cucumber"
@@ -47,6 +48,7 @@ describe('Parser - Cucumber Json', () => {
       ]
     });
   });
+  
   it('empty suite report', () => {
     const result = parse({ type: 'cucumber', files: [`${testDataPath}/empty-suite.json`] });
     assert.deepEqual(result, {
@@ -149,4 +151,14 @@ describe('Parser - Cucumber Json', () => {
       ]
     });
   });
+
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/multiple-suites-multiple-tests.json`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'cucumber', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'cucumber', files: [ relativePath]});
+    assert.notEqual(null, result2);
+  });
 });
+

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -1,10 +1,11 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - JUnit', () => {
-
+  const testDataPath = "tests/data/junit"
   it('single suite with single test', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/single-suite.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/single-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'result name',
@@ -49,7 +50,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('empty suite with single test', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/empty-suite.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/empty-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'result name',
@@ -94,7 +95,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('suite with skipped tests', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/skipped-tests.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/skipped-tests.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'result name',
@@ -139,7 +140,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('multiple suites', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/multiple-suites.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/multiple-suites.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'result name',
@@ -211,7 +212,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('multiple single suite files', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/single-suite.xml', 'tests/data/junit/single-suite.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/single-suite.xml`, `${testDataPath}/single-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'result name',
@@ -283,7 +284,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('parse newman reporter', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/newman.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/newman.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'MyCollection',
@@ -328,7 +329,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('parse newman with failures', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/newman-failures.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/newman-failures.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "MainApi",
@@ -414,7 +415,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('parse spekt/junit.testlogger', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/junit.testlogger.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/junit.testlogger.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "",
@@ -501,7 +502,7 @@ describe('Parser - JUnit', () => {
   });
 
   it('empty suite with no tests', () => {
-    const result = parse({ type: 'junit', files: ['tests/data/junit/no-suites.xml'] });
+    const result = parse({ type: 'junit', files: [`${testDataPath}/no-suites.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'no suites',
@@ -517,4 +518,12 @@ describe('Parser - JUnit', () => {
     });
   });
 
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/single-suite.xml`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'junit', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'junit', files: [relativePath]});
+    assert.notEqual(null, result2);
+  });
 });

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -1,5 +1,6 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - Mocha Json', () => {
   const testDataPath = "tests/data/mocha/json"
@@ -205,6 +206,14 @@ describe('Parser - Mocha Json', () => {
         }
       ]
     });
+  });
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/single-suite-single-test.json`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'mocha', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'mocha', files: [relativePath]});
+    assert.notEqual(null, result2);
   });
 });
 
@@ -497,5 +506,14 @@ describe('Parser - Mocha Awesmome Json', () => {
         }
       ]
     });
+  });
+
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/single-suite-single-test.json`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'mocha', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'mocha', files: [relativePath]});
+    assert.notEqual(null, result2);
   });
 });

--- a/tests/parser.testng.spec.js
+++ b/tests/parser.testng.spec.js
@@ -1,10 +1,11 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - TestNG', () => {
-
+  const testDataPath = "tests/data/testng"
   it('single suite with single test', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/single-suite.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/single-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'Default suite',
@@ -91,7 +92,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('single suite with multiple tests', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/single-suite-multiple-tests.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/single-suite-multiple-tests.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "Regression Tests",
@@ -275,7 +276,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('multiple suites with single test', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/multiple-suites-single-test.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/multiple-suites-single-test.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "Default suite",
@@ -362,7 +363,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('multiple suites with multiple tests', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/multiple-suites-multiple-tests.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/multiple-suites-multiple-tests.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "Default suite 1",
@@ -518,7 +519,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('multiple suites with retries', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/multiple-suites-retries.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/multiple-suites-retries.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "Staging - UI Smoke Test Run",
@@ -674,7 +675,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('results using glob', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/single-*.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/single-*.xml`] });
     assert.deepEqual(result, {
       "id": "",
       "name": "Regression Tests",
@@ -927,7 +928,7 @@ describe('Parser - TestNG', () => {
   });
 
   it('single suite with no test', () => {
-    const result = parse({ type: 'testng', files: ['tests/data/testng/empty-suite.xml'] });
+    const result = parse({ type: 'testng', files: [`${testDataPath}/empty-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'Empty Suite',
@@ -941,6 +942,15 @@ describe('Parser - TestNG', () => {
       status: 'PASS',
       suites: []
     });
+  });
+
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/single-suite.xml`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'testng', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'testng', files: [relativePath]});
+    assert.notEqual(null, result2);
   });
 
 });

--- a/tests/parser.xunit.spec.js
+++ b/tests/parser.xunit.spec.js
@@ -1,11 +1,13 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - XUnit', () => {
 
+  const testDataPath = "tests/data/xunit";
   
   it('single suite with single test', () => {
-    const result = parse({ type: 'xunit', files: ['tests/data/xunit/single-suite.xml'] });
+    const result = parse({ type: 'xunit', files: [`${testDataPath}/single-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'single suite test',
@@ -49,7 +51,7 @@ describe('Parser - XUnit', () => {
     });
   });
   it('suite with single skipped test', () => {
-    const result = parse({ type: 'xunit', files: ['tests/data/xunit/skipped-suite.xml'] });
+    const result = parse({ type: 'xunit', files: [`${testDataPath}/skipped-suite.xml`] });
     assert.deepEqual(result, {
       id: '',
       name: 'Skipped test',
@@ -92,7 +94,7 @@ describe('Parser - XUnit', () => {
     });
   });
   it('multiple suites', () => {
-    const result = parse({ type: 'xunit', files: ['tests/data/xunit/multiple-suites.xml'] });
+    const result = parse({ type: 'xunit', files: [`${testDataPath}/multiple-suites.xml`] });
     const expectedObj = {
       id: '',
       name: 'Multiple suites',
@@ -244,5 +246,14 @@ describe('Parser - XUnit', () => {
       ]
     }
     assert.deepEqual(result, expectedObj );
+  });
+
+  it('can support absolute and relative file paths', () => {
+    let relativePath = `${testDataPath}/single-suite.xml`;
+    let absolutePath = path.resolve(relativePath);
+    const result1 = parse({ type: 'xunit', files: [absolutePath] });
+    assert.notEqual(null, result1);
+    const result2 = parse({ type: 'xunit', files: [relativePath]});
+    assert.notEqual(null, result2);
   });
 });


### PR DESCRIPTION
Addresses issue #29 by centralizing all path logic into `resolveFilePath`