### PR TITLE
Introduce MSTest Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Parse test results from JUnit, TestNG, xUnit, Mocha(json), Cucumber(json) and ma
 | TestNG                        | ✅      |
 | JUnit                         | ✅      |
 | NUnit (v2 & v3)               | ✅      |
+| MSTest                        | ✅      |
 | xUnit                         | ✅      |
 | Mocha (json & mochawesome)    | ✅      |
 | Cucumber                      | ✅      |

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -31,7 +31,11 @@ const FORCED_ARRAY_KEYS = [
   "testng-results.suite.test",
   "testng-results.suite.test.class",
   "testng-results.suite.test.class.test-method",
-  "testng-results.suite.test.class.test-method.exception"
+  "testng-results.suite.test.class.test-method.exception",
+  "TestRun.Results.UnitTestResult",
+  "TestRun.TestDefinitions.UnitTest",
+  "TestRun.TestDefinitions.UnitTest.TestCategory.TestCategoryItem",
+  "TestRun.TestDefinitions.UnitTest.Properties.Property"
 ];
 
 const configured_parser = new XMLParser({

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -1,6 +1,7 @@
 const testng = require('./testng');
 const junit = require('./junit');
 const nunit = require('./nunit');
+const mstest = require('./mstest');
 const xunit = require('./xunit');
 const mocha = require('./mocha');
 const cucumber = require('./cucumber');
@@ -40,6 +41,8 @@ function getParser(type) {
       return xunit;
     case 'nunit':
       return nunit;
+    case 'mstest':
+      return mstest;
     case 'mocha':
       return mocha;
     case 'cucumber':

--- a/src/parsers/mstest.js
+++ b/src/parsers/mstest.js
@@ -1,0 +1,190 @@
+const { getJsonFromXMLFile } = require('../helpers/helper');
+
+const TestResult = require('../models/TestResult');
+const TestSuite = require('../models/TestSuite');
+const TestCase = require('../models/TestCase');
+
+const RESULT_MAP = {
+  Passed: "PASS",
+  Failed: "FAIL",
+  NotExecuted: "SKIP",
+}
+
+function populateMetaData(rawElement, map) {
+  if (rawElement.TestCategory && rawElement.TestCategory.TestCategoryItem) {
+    let rawCategories = rawElement.TestCategory.TestCategoryItem;
+    for (let i = 0; i < rawCategories.length; i++) {
+      let categoryName = rawCategories[i]["@_TestCategory"];
+      map.set(categoryName, "");
+
+      // create comma-delimited list of categories
+      if (map.has("Categories")) {
+        map.set("Categories", map.get("Categories").concat(",", categoryName));
+      } else {
+        map.set("Categories", categoryName);
+      }
+    }
+  }
+
+  // as per https://github.com/microsoft/vstest/issues/2480:
+  // - properties are supported by the XSD but are not included in TRX Visual Studio output
+  // - including support for properties because third-party extensions might generate this data
+  if (rawElement.Properties) {
+    let rawProperties = rawElement.Properties.Property;
+    for (let i = 0; i < rawProperties.length; i++) {
+      let key = rawProperties[i].Key ?? "not-set";
+      let val = rawProperties[i].Value ?? "";
+      map.set(key, val);
+    }
+  }
+}
+
+function getTestResultDuration(rawTestResult) {
+  // durations are represented in a timeformat with 7 digit microsecond precision
+  // TODO: introduce d3-time-format after https://github.com/test-results-reporter/parser/issues/42 is fixed.
+  return 0;
+}
+
+function getTestCaseName(rawDefinition) {
+  if (rawDefinition.TestMethod) {
+    let className = rawDefinition.TestMethod["@_className"];
+    let name = rawDefinition.TestMethod["@_name"];
+
+    // attempt to produce fully-qualified name
+    if (className) {
+      className = className.split(",")[0]; // handle strong-name scenario (typeName, assembly, culture, version)
+      return className.concat(".", name);
+    } else {
+      return name;
+    }
+  } else {
+    throw new Error("Unrecognized TestDefinition");
+  }
+}
+
+function getTestSuiteName(testCase) {
+  // assume testCase.name is full-qualified namespace.classname.methodname
+  let index = testCase.name.lastIndexOf(".");
+  return testCase.name.substring(0, index);
+}
+
+function getTestCase(rawTestResult, definitionMap) {
+  let id = rawTestResult["@_testId"];
+
+  if (definitionMap.has(id)) {
+    var rawDefinition = definitionMap.get(id);
+
+    var testCase = new TestCase();
+    testCase.id = id;
+    testCase.name = getTestCaseName(rawDefinition);
+    testCase.status = RESULT_MAP[rawTestResult["@_outcome"]];
+    testCase.duration = getTestResultDuration(rawTestResult);
+
+    // collect error messages
+    if (rawTestResult.Output && rawTestResult.Output.ErrorInfo) {
+      testCase.setFailure(rawTestResult.Output.ErrorInfo.Message);
+      testCase.stack_trace = rawTestResult.Output.ErrorInfo.StackTrace ?? '';
+    }
+    // populate meta
+    populateMetaData(rawDefinition, testCase.meta_data);
+
+    return testCase;
+  } else {
+    throw new Error(`Unrecognized testId ${id ?? ''}`);
+  }
+}
+
+function getTestDefinitionsMap(rawTestDefinitions) {
+  let map = new Map();
+
+  // assume all definitions are 'UnitTest' elements
+  if (rawTestDefinitions.UnitTest) {
+    let rawUnitTests = rawTestDefinitions.UnitTest;
+    for (let i = 0; i < rawUnitTests.length; i++) {
+      let rawUnitTest = rawUnitTests[i];
+      let id = rawUnitTest["@_id"];
+      if (id) {
+        map.set(id, rawUnitTest);
+      }
+    }
+  }
+
+  return map;
+}
+
+function getTestResults(rawTestResults) {
+  let results = [];
+
+  // assume all results are UnitTestResult elements
+  if (rawTestResults.UnitTestResult) {
+    let unitTests = rawTestResults.UnitTestResult;
+    for (let i = 0; i < unitTests.length; i++) {
+      results.push(unitTests[i]);
+    }
+  }
+  return results;
+}
+
+function getTestSuites(rawTestRun) {
+  // outcomes + durations are stored in /TestRun/TestResults/*
+  const testResults = getTestResults(rawTestRun.Results);
+  // test names and details are stored in /TestRun/TestDefinitions/*
+  const testDefinitions = getTestDefinitionsMap(rawTestRun.TestDefinitions);
+
+  // trx does not include suites, so we'll reverse engineer them by
+  // grouping results from the same className
+  let suiteMap = new Map();
+
+  for (let i = 0; i < testResults.length; i++) {
+    let rawTestResult = testResults[i];
+    let testCase = getTestCase(rawTestResult, testDefinitions);
+    let suiteName = getTestSuiteName(testCase);
+
+    if (!suiteMap.has(suiteName)) {
+      let suite = new TestSuite();
+      suite.name = suiteName;
+      suiteMap.set(suiteName, suite);
+    }
+    suiteMap.get(suiteName).cases.push(testCase);
+  }
+
+  var result = [];
+  for (let suite of suiteMap.values()) {
+    suite.total = suite.cases.length;
+    suite.passed = suite.cases.filter(i => i.status == "PASS").length;
+    suite.failed = suite.cases.filter(i => i.status == "FAIL").length;
+    suite.skipped = suite.cases.filter(i => i.status == "SKIP").length;
+    suite.errors = suite.cases.filter(i => i.status == "ERROR").length;
+    suite.duration = suite.cases.reduce((total, test) => { return total + test.duration }, 0);
+    result.push(suite);
+  }
+
+  return result;
+}
+
+function getTestResult(json) {
+  const rawTestRun = json.TestRun;
+
+  let result = new TestResult();
+  result.id = rawTestRun["@_id"];
+  result.suites.push(...getTestSuites(rawTestRun));
+
+  // calculate totals
+  result.total = result.suites.reduce((total, suite) => { return total + suite.total }, 0);
+  result.passed = result.suites.reduce((total, suite) => { return total + suite.passed }, 0);
+  result.failed = result.suites.reduce((total, suite) => { return total + suite.failed }, 0);
+  result.skipped = result.suites.reduce((total, suite) => { return total + suite.skipped }, 0);
+  result.errors = result.suites.reduce((total, suite) => { return total + suite.errors }, 0);
+  result.duration = result.suites.reduce((total, suite) => { return total + suite.duration }, 0);
+
+  return result;
+}
+
+function parse(file) {
+  const json = getJsonFromXMLFile(file);
+  return getTestResult(json);
+}
+
+module.exports = {
+  parse
+}

--- a/tests/data/mstest/testresults.trx
+++ b/tests/data/mstest/testresults.trx
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="413d0867-f074-4fe6-ab37-b766b82cd97c" name="bryan.b.cook@MYCOMPUTER 2023-11-12 19:21:51" runUser="DOMAIN\bryan.b.cook"
+    xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+    <Times creation="2023-11-12T19:21:51.7813392-05:00" queuing="2023-11-12T19:21:51.7813396-05:00" start="2023-11-12T19:21:50.8694867-05:00" finish="2023-11-12T19:21:51.8154544-05:00" />
+    <TestSettings name="default" id="155de8f5-30de-41da-bf8d-1c03eb63e978">
+        <Deployment runDeploymentRoot="bryan.b.cook_MYCOMPUTER_2023-11-12_19_21_51" />
+    </TestSettings>
+    <Results>
+        <UnitTestResult executionId="e01a54d8-305c-4828-9bc0-8c935270dafe" testId="5370a586-74b0-a647-4839-100eef3a4188" testName="FailingTest" computerName="MYCOMPUTER" duration="00:00:00.0259239" startTime="2023-11-12T19:21:51.6583003-05:00" endTime="2023-11-12T19:21:51.6978162-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e01a54d8-305c-4828-9bc0-8c935270dafe">
+            <Output>
+                <ErrorInfo>
+                    <Message>Assert.Fail failed. </Message>
+                    <StackTrace>   at MSTestSample.MockTestFixture.FailingTest() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 12&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="9915e227-fac8-4f88-b86c-a456bc7031a3" testId="2edb0741-aaff-135c-69bb-02a2e6d737cd" testName="InconclusiveTest" computerName="MYCOMPUTER" duration="00:00:00.0006505" startTime="2023-11-12T19:21:51.7029151-05:00" endTime="2023-11-12T19:21:51.7036802-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9915e227-fac8-4f88-b86c-a456bc7031a3">
+            <Output>
+                <ErrorInfo>
+                    <Message>Assert.Inconclusive failed. </Message>
+                    <StackTrace>   at MSTestSample.MockTestFixture.InconclusiveTest() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 19&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" testId="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c" testName="MockTest1" computerName="MYCOMPUTER" duration="00:00:00.0000387" startTime="2023-11-12T19:21:51.7037282-05:00" endTime="2023-11-12T19:21:51.7038253-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" />
+        <UnitTestResult executionId="01f88d1f-7d8d-402d-9c18-bf81649b3296" testId="9475a122-272d-f5ef-87e4-fe7d1a7f0418" testName="MockTest2" computerName="MYCOMPUTER" duration="00:00:00.0000219" startTime="2023-11-12T19:21:51.7038450-05:00" endTime="2023-11-12T19:21:51.7039074-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="01f88d1f-7d8d-402d-9c18-bf81649b3296" />
+        <UnitTestResult executionId="4db5da11-faef-4e70-98d1-39ee00d6ed00" testId="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351" testName="MockTest3" computerName="MYCOMPUTER" duration="00:00:00.0000196" startTime="2023-11-12T19:21:51.7039180-05:00" endTime="2023-11-12T19:21:51.7039706-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4db5da11-faef-4e70-98d1-39ee00d6ed00" />
+        <UnitTestResult executionId="68e29212-0297-4843-8f1e-cad3dfe2dd06" testId="0b5c3ebb-3086-951a-1724-1821d30aef04" testName="MockTest4" computerName="MYCOMPUTER" startTime="2023-11-12T19:21:51.7039815-05:00" endTime="2023-11-12T19:21:51.7041817-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="68e29212-0297-4843-8f1e-cad3dfe2dd06">
+            <Output></Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="685aeaf1-023c-4eb1-8727-fc6516eb1b61" testId="20aced79-1a63-4e66-d444-ee4575c65515" testName="NotRunnableTest" computerName="MYCOMPUTER" duration="00:00:00.0019388" startTime="2023-11-12T19:21:51.7042017-05:00" endTime="2023-11-12T19:21:51.7061961-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="685aeaf1-023c-4eb1-8727-fc6516eb1b61">
+            <Output>
+                <ErrorInfo>
+                    <Message>Test method MSTestSample.MockTestFixture.NotRunnableTest threw exception: &#xD;
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestFailedException: Only data driven test methods can have parameters. Did you intend to use [DataRow] or [DynamicData]?</Message>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" testId="529a01f5-6c96-4f46-49f3-aa90b9f061b6" testName="TestWithException" computerName="MYCOMPUTER" duration="00:00:00.0005719" startTime="2023-11-12T19:21:51.7062325-05:00" endTime="2023-11-12T19:21:51.7068761-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e">
+            <Output>
+                <ErrorInfo>
+                    <Message>Test method MSTestSample.MockTestFixture.TestWithException threw exception: &#xD;
+System.NotImplementedException: The method or operation is not implemented.</Message>
+                    <StackTrace>    at MSTestSample.MockTestFixture.TestWithException() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 70&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testId="c09170d3-a997-9a92-b6d5-9a86a4225591" testName="TestWithManyProperties" computerName="MYCOMPUTER" duration="00:00:00.0000490" startTime="2023-11-12T19:21:51.7069158-05:00" endTime="2023-11-12T19:21:51.7071317-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
+        
+        <UnitTestResult executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testId="dac0f7bf-eced-b506-706a-66ed33c7be60" testName="TestWithArg (1)" computerName="MYCOMPUTER" duration="00:00:00.0000574" startTime="2023-11-12T19:21:51.7314236-05:00" endTime="2023-11-12T19:21:51.7362844-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+        
+        
+    </Results>
+    <TestDefinitions>
+        <UnitTest name="FailingTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="5370a586-74b0-a647-4839-100eef3a4188">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="e01a54d8-305c-4828-9bc0-8c935270dafe" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="FailingTest" />
+        </UnitTest>
+        <UnitTest name="InconclusiveTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="2edb0741-aaff-135c-69bb-02a2e6d737cd">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="9915e227-fac8-4f88-b86c-a456bc7031a3" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="InconclusiveTest" />
+        </UnitTest>
+        <UnitTest name="MockTest1" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest1" />
+        </UnitTest>
+        <UnitTest name="MockTest2" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" priority="1" id="9475a122-272d-f5ef-87e4-fe7d1a7f0418">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+                <TestCategoryItem TestCategory="MockCategory" />
+            </TestCategory>
+            <Execution id="01f88d1f-7d8d-402d-9c18-bf81649b3296" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest2" />
+        </UnitTest>
+        <UnitTest name="MockTest3" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351">
+            <TestCategory>
+                <TestCategoryItem TestCategory="MockCategory" />
+                <TestCategoryItem TestCategory="FixtureCategory" />
+                <TestCategoryItem TestCategory="AnotherCategory" />
+            </TestCategory>
+            <Execution id="4db5da11-faef-4e70-98d1-39ee00d6ed00" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest3" />
+        </UnitTest>
+        <UnitTest name="MockTest4" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="0b5c3ebb-3086-951a-1724-1821d30aef04">
+            <TestCategory>
+                <TestCategoryItem TestCategory="Foo" />
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="68e29212-0297-4843-8f1e-cad3dfe2dd06" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest4" />
+        </UnitTest>
+        <UnitTest name="NotRunnableTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="20aced79-1a63-4e66-d444-ee4575c65515">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="685aeaf1-023c-4eb1-8727-fc6516eb1b61" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="NotRunnableTest" />
+        </UnitTest>        
+        <UnitTest name="TestWithException" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="529a01f5-6c96-4f46-49f3-aa90b9f061b6">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="TestWithException" />
+        </UnitTest>
+        <UnitTest name="TestWithManyProperties" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="c09170d3-a997-9a92-b6d5-9a86a4225591">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="TestWithManyProperties" />
+        </UnitTest>
+        <UnitTest name="TestWithArg (1)" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="dac0f7bf-eced-b506-706a-66ed33c7be60">
+            <Execution id="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCases" name="TestWithArg" />
+        </UnitTest>
+    </TestDefinitions>
+    <TestEntries>
+        <TestEntry testId="c09170d3-a997-9a92-b6d5-9a86a4225591" executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="529a01f5-6c96-4f46-49f3-aa90b9f061b6" executionId="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="9475a122-272d-f5ef-87e4-fe7d1a7f0418" executionId="01f88d1f-7d8d-402d-9c18-bf81649b3296" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c" executionId="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="2edb0741-aaff-135c-69bb-02a2e6d737cd" executionId="9915e227-fac8-4f88-b86c-a456bc7031a3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="dac0f7bf-eced-b506-706a-66ed33c7be60" executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="5370a586-74b0-a647-4839-100eef3a4188" executionId="e01a54d8-305c-4828-9bc0-8c935270dafe" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="0b5c3ebb-3086-951a-1724-1821d30aef04" executionId="68e29212-0297-4843-8f1e-cad3dfe2dd06" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="20aced79-1a63-4e66-d444-ee4575c65515" executionId="685aeaf1-023c-4eb1-8727-fc6516eb1b61" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351" executionId="4db5da11-faef-4e70-98d1-39ee00d6ed00" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    </TestEntries>
+    <TestLists>
+        <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+    </TestLists>
+    <ResultSummary outcome="Failed">
+        <Counters total="10" executed="8" passed="5" failed="3" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+        <Output>
+            <StdOut>Test 'InconclusiveTest' was skipped in the test run.&#xD;
+Test 'MockTest4' was skipped in the test run.&#xD;
+            </StdOut>
+        </Output>
+        <RunInfos>
+            <RunInfo computerName="MYCOMPUTER" outcome="Warning" timestamp="2023-11-12T19:21:51.6401483-05:00">
+                <Text>[MSTest][Discovery][C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll] UTA007: Method MockTest5 defined in class MSTestSample.MockTestFixture does not have correct signature. Test method marked with the [TestMethod] attribute must be non-static, public, return-type as void  and should not take any parameter. Example: public void Test.Class1.Test(). Additionally, if you are using async-await in test method then return-type must be Task. Example: public async Task Test.Class1.Test2()</Text>
+            </RunInfo>
+        </RunInfos>
+    </ResultSummary>
+</TestRun>

--- a/tests/parser.mstest.spec.js
+++ b/tests/parser.mstest.spec.js
@@ -1,0 +1,65 @@
+const { parse } = require('../src');
+const assert = require('assert');
+
+describe('Parser - MSTest', () => {
+
+    const testDataPath = "tests/data/mstest";
+    var result;
+
+    before(() => {
+        result = parse({ type: 'mstest', files: [`${testDataPath}/testresults.trx`] });
+    });
+
+    it('Should calculate totals', () => {
+        assert.equal(result.total, 10);
+        assert.equal(result.passed, 5);
+        assert.equal(result.failed, 3);
+        assert.equal(result.skipped, 2);
+
+        assert.equal(result.suites.length, 2);
+        //assert.equal(result.duration > 0, true); // TODO: Fix
+    })
+
+    it('Should express durations in milliseconds', () => {
+        //trx represents timestamps with microseconds
+        //assert.equal(result.suites[0].cases[0].duration, 259.239); // TODO: Fix
+    })
+
+    it('Should map results correctly', () => {
+        assert.equal(result.suites[0].cases[0].status, "FAIL");
+        assert.equal(result.suites[0].cases[1].status, "SKIP"); // inconclusive
+        assert.equal(result.suites[0].cases[2].status, "PASS");
+        assert.equal(result.suites[0].cases[3].status, "PASS");
+        assert.equal(result.suites[0].cases[4].status, "PASS");
+        assert.equal(result.suites[0].cases[5].status, "SKIP"); // ignore
+        assert.equal(result.suites[0].cases[6].status, "FAIL"); // not runnable
+        assert.equal(result.suites[0].cases[7].status, "FAIL"); // exception
+        assert.equal(result.suites[0].cases[8].status, "PASS");
+
+        assert.equal(result.suites[1].cases[0].status, "PASS"); // datarow
+    });
+
+    it('Should include fullnames for testsuites and testcases', () => {
+        assert.equal(result.suites[0].name, "MSTestSample.MockTestFixture");
+        assert.equal(result.suites[0].cases[0].name, "MSTestSample.MockTestFixture.FailingTest");
+    });
+
+    it('Should include failure and stack trace for failed test', () => {
+        assert.equal(result.suites[0].cases[0].failure, 'Assert.Fail failed.')
+        assert.equal(result.suites[0].cases[0].stack_trace, 'at MSTestSample.MockTestFixture.FailingTest() in C:\\dev\\code\\_Experiments\\MSTestSample\\UnitTest1.cs:line 12&#xD;');
+    });
+
+    it('Should include categories from suite', () => {
+        const testCaseInheritedCategories = result.suites[0].cases[0];
+        assert.equal(testCaseInheritedCategories.meta_data.has("FixtureCategory"), true);
+        assert.equal(testCaseInheritedCategories.meta_data.get("Categories"), "FixtureCategory");
+    })
+
+    it('Should combine categories from suite and case', () => {
+        const testCaseWithCategories = result.suites[0].cases[3];
+        assert.equal(testCaseWithCategories.meta_data.has("FixtureCategory"), true);
+        assert.equal(testCaseWithCategories.meta_data.has("MockCategory"), true);
+        assert.equal(testCaseWithCategories.meta_data.get("Categories"), "FixtureCategory,MockCategory");
+    });
+
+});

--- a/tests/parser.nunit.spec.js
+++ b/tests/parser.nunit.spec.js
@@ -1,6 +1,5 @@
 const { parse } = require('../src');
 const assert = require('assert');
-const path = require('path');
 
 describe('Parser - NUnit', () => {
 
@@ -238,10 +237,6 @@ describe('Parser - NUnit', () => {
 
   function sumCases(result, predicate) {
     return flattenTestCases(result).reduce( (total, testcase) => { return total + predicate(testcase)}, 0);
-  }
-
-  function findTestCaseById(result, id) {
-    return findTestCases(result, testcase => { return testcase.id == id})[0];
   }
 
   function findTestCases(result, predicate) {


### PR DESCRIPTION
This PR introduces basic support for MS Test TRX format:

```xml
<TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
  <Results>
    <UnitTestResult testId="..." duration="..." outcome="...">
      <Output>
        <ErrorInfo>
          <Message>...</Message>
          <StackTrace>...</StackTrace>
        </ErrorInfo>
       </Output>
    </UnitTestResult>
    <UnitTestResult .../>
  </Results>
  <TestDefinitions>
    <UnitTest name="..." id="...">
      <TestCategory>
        <TestCategoryItem TestCategory="..." />
      </TestCategory>
      <!-- Note Properties are supported by the Schema but are not emitted on all platforms -->
      <Properties>
        <Property>
          <Key>...</Key>
          <Value>...</Value>
        </Property>
      </Properties>
      <TestMethod className="..." name="..." />
    </UnitTest>
    <UnitTest .../>
  </TestDefinitions>
</TestRun>
```

Known issues:

- `%VSInstallDir%/Xml/Schemas/vstst.xsd` defines multiple data types under `/TestRun/Results`.

  | Element Type | Supported |
  |--|--|
  | UnitTestResult | Yes |
  | GenericTestResult | No
  | ManualTestResult | No
  | WebTestResult  | No
  | LoadTestResult | No

- `%VSInstallDir%/Xml/Schemas/vstst.xsd` defines multiple data types under `/TestRun/TestDefinitions`:
  
  | Element Type | Supported |
  |--|--|
  | UnitTest | Yes |
  | UnitTestElement | Deprecated |
  | ManualTest | No |
  | WebTest | No |
  | CodedWebTest | No |
  | OrderedTest | No |
  | LoadTest | No |
  | GenericTest | No |

- Although `Properties` are defined in the schema, they are not emitted by Visual Studio. see https://github.com/microsoft/vstest/issues/2480

- Could not replicate a test that had an "Error", so errors count on testresult and testsuite will always be empty. Invalid tests that cannot be run are not included in the test output, and details regarding their load failure are listed as plain-text in the `ResultSummary` element.
- Test durations are currently not calculated. #43

Support for the elements listed above could be introduced if we had sample xml (trx) outputs.