### PR TITLE
JUnit support for testsuite as root node

### DIFF
--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -96,7 +96,7 @@ function setAggregateResults(result) {
  */
 function getTestResult(json) {
   const result = new TestResult();
-  const rawResult = json["testsuites"][0];
+  const rawResult = json["testsuites"] ? json["testsuites"][0] : json["testsuite"];
   result.name = rawResult["@_name"] || '';
   result.total = rawResult["@_tests"];
   result.failed = rawResult["@_failures"];
@@ -111,13 +111,18 @@ function getTestResult(json) {
   result.total = result.total - result.skipped;
   result.passed = result.total - result.failed - result.errors;
   result.duration = rawResult["@_time"] * 1000;
-  const rawSuites = rawResult["testsuite"];
-  if (!(typeof rawSuites === "undefined")) { // Don't filter if there are no testsuite objects
-    const filteredSuites = rawSuites.filter(suite => suite.testcase);
-    for (let i = 0; i < filteredSuites.length; i++) {
-      result.suites.push(getTestSuite(filteredSuites[i]));
+  if (json["testsuites"]) { // top-level element is testsuites
+    const rawSuites = rawResult["testsuite"];
+    if (!(typeof rawSuites === "undefined")) { // Don't filter if there are no testsuite objects
+      const filteredSuites = rawSuites.filter(suite => suite.testcase);
+      for (let i = 0; i < filteredSuites.length; i++) {
+        result.suites.push(getTestSuite(filteredSuites[i]));
+      }
     }
+  } else { // top level element is testsuite
+    result.suites.push(getTestSuite(rawResult));
   }
+  
   setAggregateResults(result);
   result.status = result.total === result.passed ? 'PASS' : 'FAIL';
   return result;

--- a/tests/data/junit/testCafe.xml
+++ b/tests/data/junit/testCafe.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite name="TestCafe Tests" tests="2" failures="0" skipped="0" errors="0" time="211.682" timestamp="Tue, 13 Feb 2024 10:28:58 GMT" >
+  <testcase classname="Tests" file="/home/vsts/work/1/s/testcafe/tests/test1.js" name="Test1" time="15.513">
+  </testcase>
+  <testcase classname="Tests" file="/home/vsts/work/1/s/testcafe/tests/test1.js" name="Test2" time="193.695">
+  </testcase>
+</testsuite>

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -529,7 +529,7 @@ describe('Parser - JUnit', () => {
     });
   });
 
-  it('parse testcafe with testSuite root node', () => {
+  it('parse testcafe with testsuite root node', () => {
     const result = parse({ type: 'junit', files: [`${testDataPath}/testCafe.xml`] });
 
     assert.equal(result.suites.length, 1);

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -529,6 +529,13 @@ describe('Parser - JUnit', () => {
     });
   });
 
+  it('parse testcafe with testSuite root node', () => {
+    const result = parse({ type: 'junit', files: [`${testDataPath}/testCafe.xml`] });
+
+    assert.equal(result.suites.length, 1);
+    assert.equal(result.suites[0].cases.length, 2);
+  });
+
   it('empty suite with no tests', () => {
     const result = parse({ type: 'junit', files: [`${testDataPath}/no-suites.xml`] });
     assert.deepEqual(result, {


### PR DESCRIPTION
As per #46, there is some variance in JUnit reporting implementations. [According to this schema](https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd), JUnit can support a list of `testsuites` or `testsuite` as the root node:

Existing format:

```xml
<testsuites>
   <testsuite>
     <testcase/>
     <testcase/>
   </testsuite>
   <testsuite .../>
</testsuites>
```

Also supported:

```xml
<testsuite>
   <testcase/>
   <testcase/>
</testsuite>
```

