### PR TITLE
Add support for testcase.attachments

### DIFF
--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -33,9 +33,10 @@ const FORCED_ARRAY_KEYS = [
   "testng-results.suite.test.class.test-method",
   "testng-results.suite.test.class.test-method.exception",
   "TestRun.Results.UnitTestResult",
+  "TestRun.Results.UnitTestResult.ResultFiles.ResultFile",
   "TestRun.TestDefinitions.UnitTest",
-  "TestRun.TestDefinitions.UnitTest.TestCategory.TestCategoryItem",
-  "TestRun.TestDefinitions.UnitTest.Properties.Property"
+  "TestRun.TestDefinitions.UnitTest.Properties.Property",
+  "TestRun.TestDefinitions.UnitTest.TestCategory.TestCategoryItem"
 ];
 
 const configured_parser = new XMLParser({

--- a/src/helpers/helper.js
+++ b/src/helpers/helper.js
@@ -52,6 +52,7 @@ const configured_parser = new XMLParser({
         case "property":
         case "test-suite":
         case "test-case":
+        case "attachment":
           return true;
         default:
           return false;

--- a/src/models/TestAttachment.d.ts
+++ b/src/models/TestAttachment.d.ts
@@ -1,0 +1,8 @@
+declare class TestAttachment {
+  name: string;
+  path: string;
+}
+
+declare namespace TestAttachment { }
+
+export = TestAttachment;

--- a/src/models/TestAttachment.js
+++ b/src/models/TestAttachment.js
@@ -1,0 +1,10 @@
+class TestAttachment {
+
+  constructor() {
+    this.name = '';
+    this.path = '';
+  }
+
+}
+
+module.exports = TestAttachment;

--- a/src/models/TestCase.d.ts
+++ b/src/models/TestCase.d.ts
@@ -1,4 +1,5 @@
 import * as TestStep from './TestStep';
+import * as TestAttachment from './TestAttachment';
 
 declare class TestCase {
   name: string;
@@ -12,6 +13,7 @@ declare class TestCase {
   failure: string;
   stack_trace: string;
   steps: TestStep[];
+  attachments: TestAttachment[];
   meta_data: Map<string,string>;
   
   setFailure: SetFailureFunction

--- a/src/models/TestCase.js
+++ b/src/models/TestCase.js
@@ -15,6 +15,7 @@ class TestCase {
       this.failure = '';
       this.stack_trace = '';
       this.steps = [];
+      this.attachments = [];
       this.meta_data = new Map();
     }
 

--- a/src/parsers/junit.result.d.ts
+++ b/src/parsers/junit.result.d.ts
@@ -19,9 +19,10 @@ export type JUnitTestCase = {
   '@_id': string;
   '@_name': string;
   '@_time': number;
+  'system.out': string;
 }
 
-export type TestSuite = {
+export type JUnitTestSuite = {
   properties?: JUnitProperties;
   testcase: JUnitTestCase[];
   '@_id': string;

--- a/src/parsers/nunit.js
+++ b/src/parsers/nunit.js
@@ -3,6 +3,7 @@ const { getJsonFromXMLFile } = require('../helpers/helper');
 const TestResult = require('../models/TestResult');
 const TestSuite = require('../models/TestSuite');
 const TestCase = require('../models/TestCase');
+const TestAttachment = require('../models/TestAttachment');
 
 const SUITE_TYPES_WITH_TEST_CASES = [
   "TestFixture",
@@ -22,6 +23,20 @@ const RESULT_MAP = {
   Passed: "PASS",         // v3
   Failed: "FAIL",         // v3
   Skipped: "SKIP",        // v3
+}
+
+function populateAttachments(rawCase, attachments) {
+  if (rawCase.attachments && rawCase.attachments.attachment) {
+    let rawAttachments = rawCase.attachments.attachment;
+    for (var i = 0; i < rawAttachments.length; i++) {
+      var attachment = new TestAttachment();
+      attachment.path = rawAttachments[i].filePath;
+      if (rawAttachments[i].description) {
+        attachment.name = rawAttachments[i].description;
+      }
+      attachments.push(attachment);
+    }
+  }
 }
 
 function mergeMeta(map1, map2) {
@@ -130,6 +145,8 @@ function getTestCases(rawSuite, parent_meta) {
           testCase.stack_trace = errorDetails["stack-trace"]
         }
       }
+      // populate attachments
+      populateAttachments(rawCase, testCase.attachments);
       // copy parent_meta data to test case
       mergeMeta(parent_meta, testCase.meta_data);
       populateMetaData(rawCase, testCase.meta_data);

--- a/tests/data/junit/test-case-attachments.xml
+++ b/tests/data/junit/test-case-attachments.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuites id="id" name="result name" tests="1" failures="1" errors="" time="10">
+  <testsuite id="testsuite" name="suite name" tests="1" failures="1" time="10">
+    <!-- single attachment -->
+    <testcase id="testsuite.withattachment" name="include attachments" time="10">
+      <system.out>[[ATTACHMENT|/path/to/attachment.png]]
+      </system.out>
+    </testcase>
+
+    <!-- multiple attachments-->
+    <testcase id="testsuite.withattachmentmultiple" name="include multiple attachments" time="10">
+      <system.out>[[ATTACHMENT|/path/to/attachment1.png]]
+Other output
+[[ATTACHMENT|/path/to/attachment2.png]]
+      </system.out>
+    </testcase>
+
+    <!-- no attachments -->
+    <testcase id="testsuite.testcase" name="with no attachments" time="10">
+    </testcase>
+
+    <!-- zero length attachments -->
+    <testcase id="testsuite.malformedattachment" name="malformed" time="10">
+      <system.out>[[ATTACHMENT| ]]
+      </system.out>
+    </testcase>
+
+  </testsuite>
+</testsuites>

--- a/tests/data/mstest/testresults.trx
+++ b/tests/data/mstest/testresults.trx
@@ -6,6 +6,8 @@
         <Deployment runDeploymentRoot="bryan.b.cook_MYCOMPUTER_2023-11-12_19_21_51" />
     </TestSettings>
     <Results>
+
+        <!-- MockTestFixture -->
         <UnitTestResult executionId="e01a54d8-305c-4828-9bc0-8c935270dafe" testId="5370a586-74b0-a647-4839-100eef3a4188" testName="FailingTest" computerName="MYCOMPUTER" duration="00:00:00.0259239" startTime="2023-11-12T19:21:51.6583003-05:00" endTime="2023-11-12T19:21:51.6978162-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e01a54d8-305c-4828-9bc0-8c935270dafe">
             <Output>
                 <ErrorInfo>
@@ -50,11 +52,25 @@ System.NotImplementedException: The method or operation is not implemented.</Mes
         </UnitTestResult>
         <UnitTestResult executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testId="c09170d3-a997-9a92-b6d5-9a86a4225591" testName="TestWithManyProperties" computerName="MYCOMPUTER" duration="00:00:00.0000490" startTime="2023-11-12T19:21:51.7069158-05:00" endTime="2023-11-12T19:21:51.7071317-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
         
+        <!-- FixtureWithTestCases -->
         <UnitTestResult executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testId="dac0f7bf-eced-b506-706a-66ed33c7be60" testName="TestWithArg (1)" computerName="MYCOMPUTER" duration="00:00:00.0000574" startTime="2023-11-12T19:21:51.7314236-05:00" endTime="2023-11-12T19:21:51.7362844-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
         
-        
+        <!-- FixtureWithTestCaseAttachments -->
+        <UnitTestResult executionId="238c26aa-9963-4623-aeda-95ef9a6799d0" testId="40ee30b0-1c98-09a4-5020-0b5d9d182630" testName="AddOneAttachment" computerName="MYCOMPUTER" duration="00:00:00.1221116" startTime="2024-02-28T14:30:39.4675415-05:00" endTime="2024-02-28T14:30:39.6333725-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="238c26aa-9963-4623-aeda-95ef9a6799d0">
+            <ResultFiles>
+              <ResultFile path="MYCOMPUTER/dummy1.txt" />
+            </ResultFiles>
+        </UnitTestResult>
+        <UnitTestResult executionId="2b2b0f58-3d88-432c-9955-1040315f96e9" testId="b63c50f5-d54a-4566-894b-c15b37bea962" testName="AddTwoAttachment" computerName="MYCOMPUTER" duration="00:00:00.1221116" startTime="2024-02-28T14:30:39.4675415-05:00" endTime="2024-02-28T14:30:39.6333725-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2b2b0f58-3d88-432c-9955-1040315f96e9">
+            <ResultFiles>
+              <ResultFile path="MYCOMPUTER/dummy2.txt" />
+              <ResultFile path="MYCOMPUTER/dummy3.txt" />
+            </ResultFiles>
+        </UnitTestResult>
     </Results>
     <TestDefinitions>
+
+        <!-- MockTestFixture -->
         <UnitTest name="FailingTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="5370a586-74b0-a647-4839-100eef3a4188">
             <TestCategory>
                 <TestCategoryItem TestCategory="FixtureCategory" />
@@ -122,10 +138,23 @@ System.NotImplementedException: The method or operation is not implemented.</Mes
             <Execution id="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
             <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="TestWithManyProperties" />
         </UnitTest>
+
+        <!-- FixtureWithTestCases -->
         <UnitTest name="TestWithArg (1)" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="dac0f7bf-eced-b506-706a-66ed33c7be60">
             <Execution id="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
             <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCases" name="TestWithArg" />
         </UnitTest>
+
+        <!-- FixtureWithTestCaseAttachments -->
+        <UnitTest name="AddOneAttachment" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="40ee30b0-1c98-09a4-5020-0b5d9d182630">
+            <Execution id="238c26aa-9963-4623-aeda-95ef9a6799d0" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\NUnitSample\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCaseAttachments" name="AddOneAttachment" />
+        </UnitTest>
+        <UnitTest name="AddTwoAttachment" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="b63c50f5-d54a-4566-894b-c15b37bea962">
+            <Execution id="2b2b0f58-3d88-432c-9955-1040315f96e9" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\NUnitSample\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCaseAttachments" name="AddTwoAttachment" />
+        </UnitTest>
+
     </TestDefinitions>
     <TestEntries>
         <TestEntry testId="c09170d3-a997-9a92-b6d5-9a86a4225591" executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
@@ -138,6 +167,7 @@ System.NotImplementedException: The method or operation is not implemented.</Mes
         <TestEntry testId="0b5c3ebb-3086-951a-1724-1821d30aef04" executionId="68e29212-0297-4843-8f1e-cad3dfe2dd06" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
         <TestEntry testId="20aced79-1a63-4e66-d444-ee4575c65515" executionId="685aeaf1-023c-4eb1-8727-fc6516eb1b61" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
         <TestEntry testId="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351" executionId="4db5da11-faef-4e70-98d1-39ee00d6ed00" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="40ee30b0-1c98-09a4-5020-0b5d9d182630" executionId="238c26aa-9963-4623-aeda-95ef9a6799d0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
     </TestEntries>
     <TestLists>
         <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />

--- a/tests/data/nunit/nunit_v3.xml
+++ b/tests/data/nunit/nunit_v3.xml
@@ -121,5 +121,15 @@
     <test-suite type="TestFixture" id="1014" name="MockTestFixture" fullname="NUnit.Tests.TestAssembly.MockTestFixture" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
       <test-case id="1015" name="MyTest" fullname="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" result="Passed" time="0.001" asserts="0" />
     </test-suite>
+    <test-suite type="TestFixture" id="1037" name="AttachmentsFixture" fullname="NUnit.Tests.TestAssembly.AttachmentsFixture" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-case id="1038" name="TestOneAttachment" fullname="NUnit.Tests.TestAssembly.AttachmentsFixture.TestOneAttachment" result="Passed" time="0.001" asserts="0">
+        <attachments>
+          <attachment>
+            <filePath>c:\absolute\filepath\dummy.txt</filePath>
+            <description><![CDATA[my description]]></description>
+          </attachment>
+        </attachments>
+      </test-case>
+    </test-suite>
   </test-suite>
 </test-run>

--- a/tests/parser.cucumber.spec.js
+++ b/tests/parser.cucumber.spec.js
@@ -33,6 +33,7 @@ describe('Parser - Cucumber Json', () => {
           meta_data: newMap({ tags: "blue,slow", suite: "1234", tagsRaw: "@blue,@slow" }),
           cases: [
             {
+              attachments: [],
               duration: 1.59,
               errors: 0,
               failed: 0,
@@ -97,6 +98,7 @@ describe('Parser - Cucumber Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 2.56,
               errors: 0,
               failed: 0,
@@ -112,6 +114,7 @@ describe('Parser - Cucumber Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 0.28,
               errors: 0,
               failed: 0,
@@ -141,6 +144,7 @@ describe('Parser - Cucumber Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 0.52,
               errors: 0,
               failed: 0,

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -571,4 +571,8 @@ describe('Parser - JUnit', () => {
     assert.equal(result.suites[0].cases[0].meta_data.get("key1"), "override-value1");
   });
 
+  it('parse system.out to locate attachments', () => {
+    assert.fail();
+  });
+
 });

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -33,6 +33,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -80,6 +81,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -127,6 +129,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -174,6 +177,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -203,6 +207,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -250,6 +255,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -279,6 +285,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 10000,
               errors: 0,
               failed: 0,
@@ -326,6 +333,7 @@ describe('Parser - JUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 807,
               errors: 0,
               failed: 0,
@@ -370,9 +378,10 @@ describe('Parser - JUnit', () => {
           "skipped": 0,
           "duration": 446,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "Sectors - Verify 'Residential' is in list",
               "total": 0,
@@ -388,6 +397,7 @@ describe('Parser - JUnit', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "Sectors EndPoint - returns a JSON response",
               "total": 0,
@@ -414,9 +424,10 @@ describe('Parser - JUnit', () => {
           "skipped": 0,
           "duration": 634,
           "status": "PASS",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "Market Asset(id-387) response - data is as expected",
               "total": 0,
@@ -461,9 +472,10 @@ describe('Parser - JUnit', () => {
           "skipped": 1,
           "duration": 870.6800000000001,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "TestD",
               "total": 0,
@@ -479,6 +491,7 @@ describe('Parser - JUnit', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "TestC",
               "total": 0,
@@ -494,6 +507,7 @@ describe('Parser - JUnit', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "InconclusiveTest",
               "total": 0,
@@ -509,6 +523,7 @@ describe('Parser - JUnit', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "Ignored",
               "total": 0,

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -587,7 +587,22 @@ describe('Parser - JUnit', () => {
   });
 
   it('parse system.out to locate attachments', () => {
-    assert.fail();
+    const result = parse({ type: 'junit', files: ['tests/data/junit/test-case-attachments.xml'] });
+
+    // test case with 1 attachment
+    assert.equal(result.suites[0].cases[0].attachments.length, 1);
+    assert.equal(result.suites[0].cases[0].attachments[0].path, '/path/to/attachment.png');
+
+    // test case with multiple attachments
+    assert.equal(result.suites[0].cases[1].attachments.length, 2);
+    assert.equal(result.suites[0].cases[1].attachments[0].path, '/path/to/attachment1.png');
+    assert.equal(result.suites[0].cases[1].attachments[1].path, '/path/to/attachment2.png');
+
+    // test case with no attachments
+    assert.equal(result.suites[0].cases[2].attachments.length, 0);
+
+    // test case with empty or malformed attachment output
+    assert.equal(result.suites[0].cases[3].attachments.length, 0);
   });
 
 });

--- a/tests/parser.mocha.spec.js
+++ b/tests/parser.mocha.spec.js
@@ -33,6 +33,7 @@ describe('Parser - Mocha Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -97,6 +98,7 @@ describe('Parser - Mocha Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -112,6 +114,7 @@ describe('Parser - Mocha Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 0,
               errors: 0,
               failed: 0,
@@ -158,6 +161,7 @@ describe('Parser - Mocha Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 3,
               errors: 0,
               failed: 0,
@@ -173,6 +177,7 @@ describe('Parser - Mocha Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -202,6 +207,7 @@ describe('Parser - Mocha Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -259,7 +265,7 @@ describe('Parser - Mocha Json', () => {
   });
 });
 
-describe('Parser - Mocha Awesmome Json', () => {
+describe('Parser - Mocha Awesome Json', () => {
   const testDataPath = "tests/data/mocha/awesome";
 
   it('single suite with single test', () => {
@@ -289,6 +295,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -353,6 +360,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -368,6 +376,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 0,
               errors: 0,
               failed: 0,
@@ -415,6 +424,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 3,
               errors: 0,
               failed: 0,
@@ -430,6 +440,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -459,6 +470,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -506,6 +518,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 3,
               errors: 0,
               failed: 0,
@@ -521,6 +534,7 @@ describe('Parser - Mocha Awesmome Json', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,
@@ -550,6 +564,7 @@ describe('Parser - Mocha Awesmome Json', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1,
               errors: 0,
               failed: 0,

--- a/tests/parser.mstest.spec.js
+++ b/tests/parser.mstest.spec.js
@@ -62,4 +62,8 @@ describe('Parser - MSTest', () => {
         assert.equal(testCaseWithCategories.meta_data.get("Categories"), "FixtureCategory,MockCategory");
     });
 
+    it('Should include ResultFiles as test case attachments', () => {
+        assert.fail();
+    });
+
 });

--- a/tests/parser.mstest.spec.js
+++ b/tests/parser.mstest.spec.js
@@ -1,5 +1,6 @@
 const { parse } = require('../src');
 const assert = require('assert');
+const path = require('path');
 
 describe('Parser - MSTest', () => {
 
@@ -11,12 +12,12 @@ describe('Parser - MSTest', () => {
     });
 
     it('Should calculate totals', () => {
-        assert.equal(result.total, 10);
-        assert.equal(result.passed, 5);
+        assert.equal(result.total, 12);
+        assert.equal(result.passed, 7);
         assert.equal(result.failed, 3);
         assert.equal(result.skipped, 2);
 
-        assert.equal(result.suites.length, 2);
+        assert.equal(result.suites.length, 3);
         //assert.equal(result.duration > 0, true); // TODO: Fix
     })
 
@@ -63,7 +64,26 @@ describe('Parser - MSTest', () => {
     });
 
     it('Should include ResultFiles as test case attachments', () => {
-        assert.fail();
+        const testSuiteWithAttachments = result.suites[2];
+        let expectedPath1 = resolveExpectedResultFilePath("238c26aa-9963-4623-aeda-95ef9a6799d0", "dummy1.txt");
+        let expectedPath2 = resolveExpectedResultFilePath("2b2b0f58-3d88-432c-9955-1040315f96e9", "dummy2.txt");
+        let expectedPath3 = resolveExpectedResultFilePath("2b2b0f58-3d88-432c-9955-1040315f96e9", "dummy3.txt");
+
+        assert.equal(testSuiteWithAttachments.cases[0].attachments.length, 1);
+        assert.equal(testSuiteWithAttachments.cases[0].attachments[0].path, expectedPath1);
+
+        assert.equal(testSuiteWithAttachments.cases[1].attachments.length, 2);
+        assert.equal(testSuiteWithAttachments.cases[1].attachments[0].path, expectedPath2)
+        assert.equal(testSuiteWithAttachments.cases[1].attachments[1].path, expectedPath3)
     });
+
+    function resolveExpectedResultFilePath(executionId, filePath) {
+        return path.join(
+            "bryan.b.cook_MYCOMPUTER_2023-11-12_19_21_51", 
+            "In", 
+            executionId, 
+            "MYCOMPUTER",
+            filePath);
+    }
 
 });

--- a/tests/parser.nunit.spec.js
+++ b/tests/parser.nunit.spec.js
@@ -110,8 +110,8 @@ describe('Parser - NUnit', () => {
 
     it('Should calculate totals', () => {
       // totals on the testresult
-      assert.equal(result.total, 18);
-      assert.equal(result.passed, 12);
+      assert.equal(result.total, 19);
+      assert.equal(result.passed, 13);
       assert.equal(result.failed, 2);
       assert.equal(result.errors, 1); 
 
@@ -138,7 +138,7 @@ describe('Parser - NUnit', () => {
     });
 
     it('Should map results correctly', () => {
-      assert.equal(result.suites.length, 8);
+      assert.equal(result.suites.length, 9);
 
       // assemblies.mocktestfixture
       assert.equal(result.suites[0].status, "FAIL");
@@ -233,7 +233,10 @@ describe('Parser - NUnit', () => {
     });
 
     it('Should include attachments associated to test-case', () => {
-      assert.fail();
+      const testCaseWithAttachments = result.suites[8].cases[0];
+      assert.equal(testCaseWithAttachments.attachments.length, 1);
+      assert.equal(testCaseWithAttachments.attachments[0].path, "c:\\absolute\\filepath\\dummy.txt")
+      assert.equal(testCaseWithAttachments.attachments[0].name, "my description")
     });
 
   });

--- a/tests/parser.nunit.spec.js
+++ b/tests/parser.nunit.spec.js
@@ -230,8 +230,11 @@ describe('Parser - NUnit', () => {
       assert.equal(testCaseWithMultipleCategories.get("Categories"), "FixtureCategory,MockCategory");
       assert.equal(testCaseWithMultipleCategories.has("FixtureCategory"), true);
       assert.equal(testCaseWithMultipleCategories.has("MockCategory"), true);      
-    })
+    });
 
+    it('Should include attachments associated to test-case', () => {
+      assert.fail();
+    });
 
   });
 

--- a/tests/parser.testng.spec.js
+++ b/tests/parser.testng.spec.js
@@ -31,6 +31,7 @@ describe('Parser - TestNG', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               id: '',
               name: 'c2',
               total: 0,
@@ -46,6 +47,7 @@ describe('Parser - TestNG', () => {
               steps: []
             },
             {
+              attachments: [],
               id: '',
               name: 'c3',
               total: 0,
@@ -61,6 +63,7 @@ describe('Parser - TestNG', () => {
               steps: []
             },
             {
+              attachments: [],
               id: '',
               name: 'c1',
               total: 0,
@@ -76,6 +79,7 @@ describe('Parser - TestNG', () => {
               steps: []
             },
             {
+              attachments: [],
               id: '',
               name: 'c4',
               total: 0,
@@ -120,9 +124,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 202082,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -138,6 +143,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -153,6 +159,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -168,6 +175,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP_WA",
               "total": 0,
@@ -183,6 +191,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -209,9 +218,10 @@ describe('Parser - TestNG', () => {
           "skipped": 1,
           "duration": 545598,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -227,6 +237,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -242,6 +253,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -257,6 +269,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP_WA",
               "total": 0,
@@ -272,6 +285,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -316,9 +330,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 2000,
           "status": "PASS",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "c2",
               "total": 0,
@@ -334,6 +349,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c3",
               "total": 0,
@@ -349,6 +365,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c1",
               "total": 0,
@@ -364,6 +381,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c4",
               "total": 0,
@@ -408,9 +426,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 2000,
           "status": "PASS",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "c2",
               "total": 0,
@@ -426,6 +445,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c3",
               "total": 0,
@@ -441,6 +461,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c1",
               "total": 0,
@@ -456,6 +477,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c4",
               "total": 0,
@@ -482,9 +504,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 2000,
           "status": "PASS",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "c2",
               "total": 0,
@@ -500,6 +523,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c3",
               "total": 0,
@@ -515,6 +539,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c1",
               "total": 0,
@@ -530,6 +555,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c4",
               "total": 0,
@@ -574,9 +600,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 1164451,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -592,6 +619,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "PC",
               "total": 0,
@@ -607,6 +635,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "PC",
               "total": 0,
@@ -622,6 +651,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -648,9 +678,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 714100,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -666,6 +697,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "PC",
               "total": 0,
@@ -681,6 +713,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "PC",
               "total": 0,
@@ -696,6 +729,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -740,9 +774,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 202082,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -758,6 +793,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -773,6 +809,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -788,6 +825,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP_WA",
               "total": 0,
@@ -803,6 +841,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -829,9 +868,10 @@ describe('Parser - TestNG', () => {
           "skipped": 1,
           "duration": 545598,
           "status": "FAIL",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "GU",
               "total": 0,
@@ -847,6 +887,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -862,6 +903,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP",
               "total": 0,
@@ -877,6 +919,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "SBP_WA",
               "total": 0,
@@ -892,6 +935,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "CB",
               "total": 0,
@@ -918,9 +962,10 @@ describe('Parser - TestNG', () => {
           "skipped": 0,
           "duration": 2000,
           "status": "PASS",
-          meta_data: new Map(),
+          "meta_data": new Map(),
           "cases": [
             {
+              "attachments": [],
               "id": "",
               "name": "c2",
               "total": 0,
@@ -936,6 +981,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c3",
               "total": 0,
@@ -951,6 +997,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c1",
               "total": 0,
@@ -966,6 +1013,7 @@ describe('Parser - TestNG', () => {
               "steps": []
             },
             {
+              "attachments": [],
               "id": "",
               "name": "c4",
               "total": 0,

--- a/tests/parser.xunit.spec.js
+++ b/tests/parser.xunit.spec.js
@@ -33,6 +33,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 86006.5,
               errors: 0,
               failed: 0,
@@ -79,6 +80,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [ 
             {
+            attachments: [],
             duration: 1,
             errors: 0,
             failed: 0,
@@ -124,6 +126,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 84201.1799,
               errors: 0,
               failed: 0,
@@ -139,6 +142,7 @@ describe('Parser - XUnit', () => {
               total: 0
             },
             {
+              attachments: [],
               duration: 218.6713,
               errors: 0,
               failed: 0,
@@ -168,6 +172,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 1411.6188,
               errors: 0,
               failed: 0,
@@ -183,6 +188,7 @@ describe('Parser - XUnit', () => {
               total: 0
             },   
             {
+              attachments: [],
               duration: 1791.1067,
               errors: 0,
               failed: 0,
@@ -212,6 +218,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 84195.474,
               errors: 0,
               failed: 0,
@@ -241,6 +248,7 @@ describe('Parser - XUnit', () => {
           meta_data: new Map(),
           cases: [
             {
+              attachments: [],
               duration: 86006.7435,
               errors: 0,
               failed: 0,


### PR DESCRIPTION
This PR introduces extends testcase with an attachments array. Currently supported for the following implementations:

- [ ] Cucumber
- [x] JUnit
- [x] MSTest
- [x] NUnit
- [ ] ~~XUnit~~ (not supported)

A few implementation notes:

- **JUnit**:

  Based on the [Jenkins Plugin Attachment plugin][junit-attachments] which inspects the `<system.out>` property in the XML for the following syntax: `[[ATTACHMENT|/absolute/path/tofile.png]]`

  I have confirmed that the azure-devops build-agent test publisher uses this convention as well. The path can be an absolute path or relative to the location of the test results xml.

  ![image](https://github.com/test-results-reporter/parser/assets/3217452/fbc67ea8-a792-4e5c-96eb-2e6ecdfb70d9)

[junit-attachments]: https://plugins.jenkins.io/junit-attachments/

- **MSTest**:

  Attachments appear in the xml under the test result for a given execution:

  ```xml
  <TestRun name="username_machinename 2024-02-28 17:25:00">
    <Results>
      <UnitTestResult executionId="xxxx" testId="yyyy">
        <ResultFiles>
          <ResultFile path="machinename/file.txt" />
        </ResultFiles>
       </UnitTestResult>
    </Results>
    <TestDefinitions>
      <UnitTest id="yyyy">
      </UnitTest>
    </TestDefinitions>
  </TestRun>
  ```


  Calls to `TestContext.AddResultFile(filename)` copies the file into a special folder per test, which is a combination of TestRun name + Test Execution id + Machine Name, relative to the location of the test results xml file.

  ```tree
  testResults.trx
  \<username>_<machinename>_<timestamp>
    \In
      \<testexecutionid>
        \<machinename>
          file.txt
  ```
  The test-parser mstest implementation expands out the relative path from the XML into a value that can be resolved at runtime relative to the test results xml file.

- **NUnit**:

   Very straight-forward as NUnit only accepts absolute paths.

Addresses:

- #49 