### PR TITLE
bugfix: Addressed unmapped mstest top-level result

### DIFF
--- a/src/parsers/mstest.js
+++ b/src/parsers/mstest.js
@@ -193,6 +193,7 @@ function getTestSuites(rawTestRun) {
     suite.skipped = suite.cases.filter(i => i.status == "SKIP").length;
     suite.errors = suite.cases.filter(i => i.status == "ERROR").length;
     suite.duration = suite.cases.reduce((total, test) => { return total + test.duration }, 0);
+    suite.status = (suite.failed + suite.errors) > 0 ? "FAIL" : "PASS";
     result.push(suite);
   }
 
@@ -213,6 +214,8 @@ function getTestResult(json) {
   result.skipped = result.suites.reduce((total, suite) => { return total + suite.skipped }, 0);
   result.errors = result.suites.reduce((total, suite) => { return total + suite.errors }, 0);
   result.duration = result.suites.reduce((total, suite) => { return total + suite.duration }, 0);
+
+  result.status = (result.failed + result.errors) > 0 ? "FAIL" : "PASS";
 
   return result;
 }

--- a/tests/data/mstest/testresults_pass.trx
+++ b/tests/data/mstest/testresults_pass.trx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="413d0867-f074-4fe6-ab37-b766b82cd97c" name="bryan.b.cook@MYCOMPUTER 2023-11-12 19:21:51" runUser="DOMAIN\bryan.b.cook"
+    xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+    <Times creation="2023-11-12T19:21:51.7813392-05:00" queuing="2023-11-12T19:21:51.7813396-05:00" start="2023-11-12T19:21:50.8694867-05:00" finish="2023-11-12T19:21:51.8154544-05:00" />
+    <TestSettings name="default" id="155de8f5-30de-41da-bf8d-1c03eb63e978">
+        <Deployment runDeploymentRoot="bryan.b.cook_MYCOMPUTER_2023-11-12_19_21_51" />
+    </TestSettings>
+    <Results>
+
+        <!-- FixtureWithTestCases -->
+        <UnitTestResult executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testId="dac0f7bf-eced-b506-706a-66ed33c7be60" testName="TestWithArg (1)" computerName="MYCOMPUTER" duration="00:00:00.0000574" startTime="2023-11-12T19:21:51.7314236-05:00" endTime="2023-11-12T19:21:51.7362844-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+        
+    </Results>
+    <TestDefinitions>
+
+        <!-- FixtureWithTestCases -->
+        <UnitTest name="TestWithArg (1)" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="dac0f7bf-eced-b506-706a-66ed33c7be60">
+            <Execution id="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCases" name="TestWithArg" />
+        </UnitTest>
+
+    </TestDefinitions>
+    <TestEntries>
+        <TestEntry testId="dac0f7bf-eced-b506-706a-66ed33c7be60" executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    </TestEntries>
+    <TestLists>
+        <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+    </TestLists>
+    <ResultSummary outcome="Passed">
+        <Counters total="1" executed="1" passed="1" failed="0" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    </ResultSummary>
+</TestRun>

--- a/tests/parser.mstest.spec.js
+++ b/tests/parser.mstest.spec.js
@@ -27,6 +27,11 @@ describe('Parser - MSTest', () => {
     })
 
     it('Should map results correctly', () => {
+        assert.equal(result.status, "FAIL");
+
+        // assert suite results
+        assert.equal(result.suites[0].status, "FAIL")
+
         assert.equal(result.suites[0].cases[0].status, "FAIL");
         assert.equal(result.suites[0].cases[1].status, "SKIP"); // inconclusive
         assert.equal(result.suites[0].cases[2].status, "PASS");
@@ -37,7 +42,10 @@ describe('Parser - MSTest', () => {
         assert.equal(result.suites[0].cases[7].status, "FAIL"); // exception
         assert.equal(result.suites[0].cases[8].status, "PASS");
 
+        assert.equal(result.suites[1].status, "PASS")
         assert.equal(result.suites[1].cases[0].status, "PASS"); // datarow
+
+        assert.equal(result.suites[2].status, "PASS")
     });
 
     it('Should include fullnames for testsuites and testcases', () => {
@@ -75,6 +83,11 @@ describe('Parser - MSTest', () => {
         assert.equal(testSuiteWithAttachments.cases[1].attachments.length, 2);
         assert.equal(testSuiteWithAttachments.cases[1].attachments[0].path, expectedPath2)
         assert.equal(testSuiteWithAttachments.cases[1].attachments[1].path, expectedPath3)
+    });
+
+    it('Should report overall status as PASS if all tests pass', () => {
+        const result = parse({ type: 'mstest', files: [`${testDataPath}/testresults_pass.trx`] });
+        assert.equal(result.status, "PASS");    
     });
 
     function resolveExpectedResultFilePath(executionId, filePath) {


### PR DESCRIPTION
Inspired by the bug discovered in #63, I confirmed that this defect was also present in the MSTest implementation.