### PR TITLE
Add support for junit properties in system.out

### DIFF
--- a/tests/data/junit/inline-properties-suite-level.xml
+++ b/tests/data/junit/inline-properties-suite-level.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<testsuites id="id" name="result name" tests="1" failures="1" errors="" time="10">
+  <testsuite name="Inline Properties Suite Level" tests="1" failures="0" errors="0" skipped="0">
+    <system-out>
+Output line #1
+Output line #2
+
+[[PROPERTY|author=Adrian]]
+[[PROPERTY|language=english]]
+
+[[PROPERTY|browser-log]]
+Log line #1
+Log line #2
+Log line #3
+[[/PROPERTY]]
+    </system-out>
+    <testcase name="testCaseWithNoInlineProperties" classname="Tests.Registration" time="3.441"/>
+  </testsuite>
+</testsuites>

--- a/tests/data/junit/inline-properties.xml
+++ b/tests/data/junit/inline-properties.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<testsuites id="id" name="result name" tests="1" failures="1" errors="" time="10">
+  <testsuite name="Inline Properties Suite" tests="1" failures="0" errors="0" skipped="0">
+    <testcase name="testCaseWithInlineProperties" classname="Tests.Registration" time="3.441">
+      <system-out>
+Output line #1
+Output line #2
+
+[[PROPERTY|author=Adrian]]
+[[PROPERTY|language=english]]
+
+[[PROPERTY|browser-log]]
+Log line #1
+Log line #2
+Log line #3
+  [[/PROPERTY]]
+      </system-out>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/tests/parser.junit.spec.js
+++ b/tests/parser.junit.spec.js
@@ -566,6 +566,34 @@ describe('Parser - JUnit', () => {
     assert.equal(result.suites[0].cases[3].attachments.length, 0);
   });
 
+  it('parse system.out to locate properties (testcase)', () => {
+    const result = parse({ type: 'junit', ignore_error_count: true, files: [`${testDataPath}/inline-properties.xml`] });
+
+    assert.deepEqual(result.suites[0].cases[0].metadata, {
+      author: 'Adrian',
+      language: 'english',
+      'browser-log': 'Log line #1\nLog line #2\nLog line #3'
+    });
+  });
+
+  it('parse system.out to locate properties (suite)', () => {
+    const result = parse({ type: 'junit', files: [`${testDataPath}/inline-properties-suite-level.xml`] });
+
+    // verify properties were set at the suite level
+    assert.deepEqual(result.suites[0].metadata, {
+      author: 'Adrian',
+      language: 'english',
+      'browser-log': 'Log line #1\nLog line #2\nLog line #3'
+    });
+
+    // verify properties were inherited at the test case level
+    assert.deepEqual(result.suites[0].cases[0].metadata, {
+      author: 'Adrian',
+      language: 'english',
+      'browser-log': 'Log line #1\nLog line #2\nLog line #3'
+    });
+  });
+
   it('wdio - multiple files', () => {
     const result = parse({ type: 'junit', files: [`${testDataPath}/wdio/*.xml`] });
     assert.equal(result.total, 9);
@@ -605,5 +633,7 @@ describe('Parser - JUnit', () => {
     assert.equal(result.suites[1].cases[1].attachments[0].name, `test-failed-1.png`);
     assert.equal(result.suites[1].cases[1].attachments[0].path, `example-get-started-link-chromium/test-failed-1.png`);
   });
+
+
 
 });


### PR DESCRIPTION
To accommodate JUnit loggers that do not support property syntax, this PR modifies the JUnit parser to parse the `system.out` element at the suite and testcase level for properties with the following syntax:

- Single line expression: 

```
[[PROPERTY|propertyName=value]]
```

- Multi line expression: 
  
```
[[PROPERTY|propertyName]]
line1\n
line2\n
line3
[[/PROPERTY]]
```

Note to reviewers: Copilot + Codespaces were used to guide this feature.

Resolves #53 