### PR TITLE
Add support for durations in mstest

### DIFF
--- a/src/parsers/mstest.js
+++ b/src/parsers/mstest.js
@@ -69,8 +69,19 @@ function populateAttachments(rawResultElement, attachments, testRunName) {
 
 function getTestResultDuration(rawTestResult) {
   // durations are represented in a timeformat with 7 digit microsecond precision
-  // TODO: introduce d3-time-format after https://github.com/test-results-reporter/parser/issues/42 is fixed.
-  return 0;
+  const durationString = rawTestResult["@_duration"];
+  if (!durationString) return 0;
+
+  // Split the duration into hours, minutes, seconds, and microseconds
+  const [hours, minutes, seconds] = durationString.split(':');
+
+  // Convert everything to milliseconds
+  const totalMilliseconds =
+    parseInt(hours) * 3600000 + // hours to ms
+    parseInt(minutes) * 60000 + // minutes to ms
+    parseFloat(seconds) * 1000; // seconds to ms
+
+  return totalMilliseconds.toFixed(4);
 }
 
 function getTestCaseName(rawDefinition) {

--- a/tests/parser.mstest.spec.js
+++ b/tests/parser.mstest.spec.js
@@ -22,8 +22,24 @@ describe('Parser - MSTest', () => {
   })
 
   it('Should express durations in milliseconds', () => {
-    //trx represents timestamps with microseconds
-    //assert.equal(result.suites[0].cases[0].duration, 259.239); // TODO: Fix
+    //trx represents timestamps with microseconds 00:00:00.1234567
+    const testDataPath = "tests/data/mstest/testresults.trx";
+    const result = parse({ type: 'mstest', files: [testDataPath] });
+
+    const failingTest = result.suites[0].cases.find(test => test.name === 'MSTestSample.MockTestFixture.FailingTest');
+    assert.equal(failingTest.duration, 25.9239);
+
+    const inconclusiveTest = result.suites[0].cases.find(test => test.name === 'MSTestSample.MockTestFixture.InconclusiveTest');
+    assert.equal(inconclusiveTest.duration, 0.6505);
+
+    const mockTest1 = result.suites[0].cases.find(test => test.name === 'MSTestSample.MockTestFixture.MockTest1');
+    assert.equal(mockTest1.duration, 0.0387);
+
+    const mockTest2 = result.suites[0].cases.find(test => test.name === 'MSTestSample.MockTestFixture.MockTest2');
+    assert.equal(mockTest2.duration, 0.0219);
+
+    const mockTest3 = result.suites[0].cases.find(test => test.name === 'MSTestSample.MockTestFixture.MockTest3');
+    assert.equal(mockTest3.duration, 0.0196);
   })
 
   it('Should map results correctly', () => {


### PR DESCRIPTION
This PR introduces a gap in mstest duration parsing.

Note to reviewers: Copilot + Codespaces were used to guide this feature.

Resolves: #43 