### PR TITLE
Add devcontainer for Github Codespace 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "testparser project",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+  "customizations": {
+    "vscode": {
+      "extensions": ["hbenl.vscode-mocha-test-adapter"]
+    }
+  },
+  "postCreateCommand": "npm install"
+}


### PR DESCRIPTION
This PR introduces a `.devcontainer` configuration for use with GitHub Codespaces.

The `.devcontainer` has the Mocha Test Explorer extension enabled by default, which makes it easy to quickly launch a new Codespace in a browser and run the tests.

![image](https://github.com/user-attachments/assets/c89413e7-1a58-4716-8524-b2f2e25e00d7)

