### PR TITLE
Add variable declaration to prevent failures when the code is bundled

### DIFF
--- a/src/parsers/junit.js
+++ b/src/parsers/junit.js
@@ -133,6 +133,7 @@ function setAttachments(rawCase, test_element) {
     // junit attachments plug syntax is [[ATTACHMENT|/absolute/path/to/file.png]]
     const regex = new RegExp('\\[\\[ATTACHMENT\\|([^\\]]+)\\]\\]', 'g');
 
+    let m;
     while ((m = regex.exec(systemOut)) !== null) {
       // avoid infinite loops with zero-width matches
       if (m.index === regex.lastIndex) {


### PR DESCRIPTION
Hi, when using this library together with a bundler (rollup/rolldown) parsing of JUnit reports containing system-out fails with the `ReferenceError: m is not defined!` error.

This seems to be caused by a missing variable declaration which this PR aims to fix.